### PR TITLE
Aj correlation measures

### DIFF
--- a/xmipp3/protocols/protocol_compare_reprojections.py
+++ b/xmipp3/protocols/protocol_compare_reprojections.py
@@ -171,7 +171,9 @@ class XmippProtCompareReprojections(ProtAnalysis3D, ProjMatcher):
                            xmippLib.MDL_ZSCORE_RESCOV, xmippLib.MDL_IMAGE_ORIGINAL,
                            xmippLib.MDL_COST, xmippLib.MDL_CONTINUOUS_GRAY_A,
                            xmippLib.MDL_CONTINUOUS_GRAY_B, xmippLib.MDL_CONTINUOUS_X,
-                           xmippLib.MDL_CONTINUOUS_Y)
+                           xmippLib.MDL_CONTINUOUS_Y,
+                           xmippLib.MDL_CORRELATION_IDX, xmippLib.MDL_CORRELATION_MASK,
+                           xmippLib.MDL_CORRELATION_WEIGHT, xmippLib.MDL_IMED)
         def __setXmippImage(label):
             attr = '_xmipp_' + xmippLib.label2Str(label)
             if not hasattr(particle, attr):


### PR DESCRIPTION
Adding correlation measures (using a mask based on std and using the difference between images to calculate it) were added to filters. Also, in angular_continuos_assign2 and, finally, in the compare reprojections protocol.
This way, more correlation measures are available to the users to discover if there are several populations in the sample.