### PR TITLE
Updated CTF protocol to avoid global ctf params from base class

### DIFF
--- a/xmipp3/protocols/protocol_ctf_micrographs.py
+++ b/xmipp3/protocols/protocol_ctf_micrographs.py
@@ -350,14 +350,14 @@ class XmippProtCTFMicrographs(em.ProtCTFMicrographs):
                            })
             # Mapping between base protocol parameters and the package specific
             # command options
-            self.__params = {'sampling_rate': self._params['samplingRate'],
+            self.__params = {'sampling_rate': params['samplingRate'],
                              'downSamplingPerformed': downFactor,
-                             'kV': self._params['voltage'],
-                             'Cs': self._params['sphericalAberration'],
+                             'kV': params['voltage'],
+                             'Cs': params['sphericalAberration'],
                              'min_freq': line[3],
                              'max_freq': line[4],
-                             'defocusU': self._params['defocusU'],
-                             'Q0': self._params['ampContrast'],
+                             'defocusU': params['defocusU'],
+                             'Q0': params['ampContrast'],
                              'defocus_range': 5000,
                              'ctfmodelSize': size
                              }


### PR DESCRIPTION
This should be reviewer after https://github.com/I2PC/scipion/pull/1956 in the main branch (ctf-params branch there as well).