### PR TITLE
remove line  outVol.setObjLabel(vol.getObjLabel())

### DIFF
--- a/xmipp3/protocols/protocol_align_volume.py
+++ b/xmipp3/protocols/protocol_align_volume.py
@@ -189,7 +189,6 @@ class XmippProtAlignVolume(em.ProtAlignVolume):
         for vol in self._iterInputVolumes():
             outVol = em.Volume()
             outVol.setLocation(vol.outputName)
-            outVol.setObjLabel(vol.getObjLabel())
             outVol.setObjComment(vol.getObjComment())
             #set transformation matrix             
             volId = vol.getObjId()


### PR DESCRIPTION
outVol.setObjLabel(vol.getObjLabel()) asigns to the new volume exactly the same label than the input volume has. In this way they are two different objects with the same alias and therefore, there is no way to distinguish them. I did not remove the line:

            outVol.setObjComment(vol.getObjComment())

but I also think it should be gone