### PR TITLE
Use pointers with extended in test

### DIFF
--- a/xmipp3/protocols/protocol_movie_average.py
+++ b/xmipp3/protocols/protocol_movie_average.py
@@ -30,6 +30,7 @@ import os
 
 import pyworkflow.protocol.params as params
 from pyworkflow import VERSION_1_1
+from pyworkflow.utils import getExt
 from pyworkflow.em.protocol import ProtAlignMovies
 
 from xmipp3.convert import writeMovieMd
@@ -158,7 +159,11 @@ class XmippProtMovieAverage(ProtAlignMovies):
     #--------------------------- UTILS functions -------------------------------
     def _getShiftsFile(self, movie):
         return self._getExtraPath(self._getMovieRoot(movie) + '_shifts.xmd')
-    
+
+    def _getConvertExtension(self, filename):
+        ext = getExt(filename).lower()
+        return None if ext in ['.mrc', '.mrcs', '.tiff', '.tif', '.stk'] else 'mrc'
+
     def _createOutputMovies(self):
         """ Returns True if an output set of movies will be generated.
         The most common case is to always generate output movies,

--- a/xmipp3/tests/test_protocols_xmipp_mics.py
+++ b/xmipp3/tests/test_protocols_xmipp_mics.py
@@ -843,8 +843,9 @@ class TestXmippParticlesPickConsensus(TestXmippBase):
 
         protConsOr = self.newProtocol(XmippProtConsensusPicking,
                                       consensus=1)
-        protConsOr.inputCoordinates.set([self.protFaPi.outputCoordinates,
-                                        protAutomaticPP.outputCoordinates])
+        protConsOr.inputCoordinates.set(
+            [Pointer(self.protFaPi, extended="outputCoordinates"),
+             Pointer(protAutomaticPP, "outputCoordinates")])
         self.launchProtocol(protConsOr)
 
         self.assertTrue(protConsOr.isFinished(), "Consensus failed")
@@ -875,8 +876,9 @@ class TestXmippParticlesPickConsensus(TestXmippBase):
             protAutoPP = self._updateProtocol(protAutoPP)
 
         protCons2 = self.newProtocol(XmippProtConsensusPicking)
-        protCons2.inputCoordinates.set([self.protFaPi.outputCoordinates,
-                                        protAutoPP.outputCoordinates])
+        protCons2.inputCoordinates.set(
+            [Pointer(self.protFaPi, extended="outputCoordinates"),
+             Pointer(protAutoPP, extended="outputCoordinates")])
         self.launchProtocol(protCons2)
         self.assertTrue(protCons2.isFinished(), "Consensus failed")
         self.assertTrue(protCons2.consensusCoordinates.getSize() == 390,


### PR DESCRIPTION
If we link a protocol directly to an output like: 

prot.inputParticles.set(ptotImport.outputParticles)

It will work but copy, export to json will lose the link. It is better to do:

prot.inputParticles.set(ptotImport)
prot.inputParticles.setExtended("outputParticles")

Or as in this PR, Create a pointer to a protocol and set the extended.