### PR TITLE
fix import

### DIFF
--- a/xmipp3/protocols/protocol_volume_local_sharpening.py
+++ b/xmipp3/protocols/protocol_volume_local_sharpening.py
@@ -35,7 +35,7 @@ from pwem.objects import Volume
 import numpy as np
 import os
 import pwem.metadata as md
-from pwem.metadata.constants import (MDL_COST, MDL_ITER, MDL_SCALE)
+from pwem.metadata.constants2 import (MDL_COST, MDL_ITER, MDL_SCALE)
 from ntpath import dirname
 from os.path import exists
 


### PR DESCRIPTION
this is just one line. 
    from pwem.metadata.constants import (MDL_COST, MDL_ITER, MDL_SCALE)

should be

  from pwem.metadata.constants2 import (MDL_COST, MDL_ITER, MDL_SCALE)

 