### PR TITLE
Mm python3 migration objectView

### DIFF
--- a/xmipp3/protocols/protocol_volume_local_sharpening.py
+++ b/xmipp3/protocols/protocol_volume_local_sharpening.py
@@ -35,7 +35,7 @@ from pwem.objects import Volume
 import numpy as np
 import os
 import pwem.metadata as md
-from pwem.metadata.constants import (MDL_COST, MDL_ITER, MDL_SCALE)
+from pwem.metadata.constants2 import (MDL_COST, MDL_ITER, MDL_SCALE)
 from ntpath import dirname
 from os.path import exists
 

--- a/xmipp3/viewers/viewer_extract_unit_cell.py
+++ b/xmipp3/viewers/viewer_extract_unit_cell.py
@@ -33,8 +33,8 @@ import pyworkflow.protocol.params as params
 from pwem.constants import SYM_I222
 from pwem.convert import ImageHandler
 from pwem.objects import (SetOfVolumes)
-from pyworkflow.viewer import DESKTOP_TKINTER, WEB_DJANGO, ProtocolViewer
-from pwem.viewers import Chimera, ChimeraView
+from pyworkflow.viewer import DESKTOP_TKINTER, WEB_DJANGO
+from pwem.viewers import Chimera, ChimeraView, EmProtocolViewer
 from xmipp3.protocols.protocol_extract_unit_cell import XmippProtExtractUnit
 from xmipp3.constants import (XMIPP_TO_SCIPION, XMIPP_I222)
 
@@ -42,7 +42,7 @@ VOLUME_SLICES = 1
 VOLUME_CHIMERA = 0
 
 
-class viewerXmippProtExtractUnit(ProtocolViewer):
+class viewerXmippProtExtractUnit(EmProtocolViewer):
     """ Visualize the input and output volumes of protocol XmippProtExtractUnit
         by choosing Chimera (3D) or Xmipp visualizer (2D).
         The axes of coordinates x, y, z will be shown by choosing Chimera"""


### PR DESCRIPTION
Dear all,
here you are the small modification of the file viewer_extract_unit_cell.py, in which we replace the import of ProtocolView (from pyworkflow.viewer import ProtocolViewer) by the import of EmProtocolViewer (from pwem.viewers import EmProtocolViewer) to allow the functioning of method "objectView".