### PR TITLE
Jj mask3d set origin only geometry

### DIFF
--- a/xmipp3/protocols/protocol_preprocess/geometrical_mask.py
+++ b/xmipp3/protocols/protocol_preprocess/geometrical_mask.py
@@ -33,7 +33,7 @@ from xmipp3.constants import *
 class XmippGeometricalMask3D:
     """ Basic class for protocols using geometrical masks 3D"""
     
-    def defineParams(self, form, isGeometry, addSize, isFeature='False'):
+    def defineParams(self, form, isGeometry, addSize):
         # For geometrical sources
         if addSize:
             form.addParam('size', IntParam, condition=isGeometry, 
@@ -53,9 +53,9 @@ class XmippGeometricalMask3D:
                       help="Mask radius, if -1, the radius will be MaskSize/2")
         
         form.addParam('shiftCenter', BooleanParam, default=False,
-                      label='Shift center of the mask?', condition="%s"%isFeature)
+                      label='Shift center of the mask?', condition="%s" % isGeometry)
         
-        line = form.addLine('Shift Center (px) :', condition='shiftCenter',
+        line = form.addLine('Shift Center (px) :', condition='shiftCenter and %s' % isGeometry,
                             help='Shift Mask Center to a new origin.')
         line.addParam('centerX', IntParam, default=0, label='X')
         line.addParam('centerY', IntParam, default=0, label='Y')

--- a/xmipp3/protocols/protocol_preprocess/protocol_create_mask3d.py
+++ b/xmipp3/protocols/protocol_preprocess/protocol_create_mask3d.py
@@ -70,7 +70,7 @@ class XmippProtCreateMask3D(ProtCreateMask3D, XmippGeometricalMask3D):
     def _defineParams(self, form):
         form.addSection(label='Mask generation')
         form.addParam('source', EnumParam, default=SOURCE_VOLUME,
-                      choices=['Volume','Geometry','Feature File'	],
+                      choices=['Volume', 'Geometry', 'Feature File'	],
                       label='Mask source')
         # For volume sources
         isVolume = 'source==%d' % SOURCE_VOLUME
@@ -78,7 +78,7 @@ class XmippProtCreateMask3D(ProtCreateMask3D, XmippGeometricalMask3D):
                       label="Input volume",  condition=isVolume,
                       help="Select the volume that will be used to create the mask")
         form.addParam('volumeOperation', EnumParam, default=OPERATION_THRESHOLD,
-                      choices=['Threshold','Segment','Only postprocess'],
+                      choices=['Threshold', 'Segment', 'Only postprocess'],
                       label='Operation', condition=isVolume)
         #TODO: add wizard
         form.addParam('threshold', FloatParam, default=0.0,
@@ -89,8 +89,8 @@ class XmippProtCreateMask3D(ProtCreateMask3D, XmippGeometricalMask3D):
         form.addParam('segmentationType', EnumParam, default=SEGMENTATION_DALTON, 
                       condition=isSegmentation,
                       label='Segmentation type',
-                      choices=['Number of voxels','Number of aminoacids',
-                               'Dalton mass','Automatic'])
+                      choices=['Number of voxels', 'Number of aminoacids',
+                               'Dalton mass', 'Automatic'])
         form.addParam('nvoxels', IntParam, 
                       condition='%s and segmentationType==%d'
                       % (isSegmentation, SEGMENTATION_VOXELS),
@@ -111,9 +111,7 @@ class XmippProtCreateMask3D(ProtCreateMask3D, XmippGeometricalMask3D):
         XmippGeometricalMask3D.defineParams(self, form, 
                                             isGeometry='source==%d'
                                             % SOURCE_GEOMETRY,
-                                            addSize=True, 
-                                            isFeature='source!=%d'
-                                            % SOURCE_FEATURE_FILE)
+                                            addSize=True)
         # Feature File
         isFeatureFile = 'source==%d' % SOURCE_FEATURE_FILE
         form.addParam('featureFilePath', PathParam,

--- a/xmipp3/protocols/protocol_resolution_monogenic_signal.py
+++ b/xmipp3/protocols/protocol_resolution_monogenic_signal.py
@@ -450,18 +450,18 @@ class XmippProtMonoRes(ProtAnalysis3D):
         # viewer (otherwise since imageFile is not a Scipion object
         # no sampling/origin information can be transfered
 
-        Ccp4Header(imageFile).copyCCP4Header(
-            inputVolumeFileName, volume.getShiftsFromOrigin(),
-            volume.getSamplingRate(), originField=Ccp4Header.START)
+        Ccp4Header(imageFile).copyCCP4Header(volume.getShiftsFromOrigin(),
+                                             volume.getSamplingRate(),
+                                             originField=Ccp4Header.START)
 
         # also update the output volume header. This is not needed
         # since sampling and origin is in the database but
         # it may be usefull if other programs -outside scipion-
         # require  these data.
 
-        Ccp4Header(volume.getFileName()).copyCCP4Header(
-             inputVolumeFileName, volume.getShiftsFromOrigin(),
-             volume.getSamplingRate(), originField=Ccp4Header.START)
+        Ccp4Header(volume.getFileName()).copyCCP4Header(volume.getShiftsFromOrigin(),
+                                                        volume.getSamplingRate(),
+                                                        originField=Ccp4Header.START)
 
 
 

--- a/xmipp3/viewers/__init__.py
+++ b/xmipp3/viewers/__init__.py
@@ -28,7 +28,6 @@ from .viewer import XmippViewer
 from .plotter import XmippPlotter
 
 from .viewer_cl2d import XmippCL2DViewer
-from .viewer_cltomo import XmippCLTomoViewer
 from .viewer_ctf_consensus import XmippCTFConsensusViewer
 from .viewer_deep_consensus import XmippDeepConsensusViewer
 from .viewer_deep_micrograph_cleaner import XmippDeepMicrographViewer


### PR DESCRIPTION
Option 'shift center of the mask is now only available for mask of type Geometry when creating a 3d mask.
Tests that uses the classes edited pass or fail due to a non-related reason to the change (failed before the change).
First commit message is wrong. It is related to the correction of the calling to copy ccp4Header.