### PR TITLE
protocol operate_volumes and operate_images do not work

### DIFF
--- a/xmipp3/protocols/protocol_preprocess/protocol_image_operate.py
+++ b/xmipp3/protocols/protocol_preprocess/protocol_image_operate.py
@@ -116,7 +116,7 @@ class XmippOperateHelper():
 
     #--------------------------- DEFINE param functions -----------------------
     def _defineProcessParams(self, form):
-        form.addParam('operation', params.EnumParam, choices=OP_CHOICES.values(),
+        form.addParam('operation', params.EnumParam, choices=list(OP_CHOICES.values()),
                       default=OP_PLUS,
                       label="Operation",
                       help="Binary operations: \n"


### PR DESCRIPTION

  Scipion menu system, when creating pull-down menus, assumes that the object that contains the options is iterable and indexable. "operate" protocols in xmipp use ordered_dictionaries.values() as container for the options. This is OK in python2 but in Python 3, dictionaries (including OrderedDict) return view objects from their keys() and values() methods. Those are iterable, but don't support indexing.

Therefore I have cast "ordered_dictionaries.values()" to a list. That is
list(ordered_dictionaries.values()).

-----------------------
Error returned by the protocol if the above described change is not included

Traceback (most recent call last):
  File "/usr/local/lib/python3.8/tkinter/__init__.py", line 1883, in __call__
    return self.func(*args)
  File "/home/roberto/scipion3/scipion-pyworkflow/pyworkflow/gui/project/viewprotocols.py", line 1411, in _protocolItemClick
    self._openProtocolForm(prot)
  File "/home/roberto/scipion3/scipion-pyworkflow/pyworkflow/gui/project/viewprotocols.py", line 1659, in _openProtocolForm
    w = FormWindow(Message.TITLE_NAME_RUN + prot.getClassName(),
  File "/home/roberto/scipion3/scipion-pyworkflow/pyworkflow/gui/form.py", line 1589, in __init__
    self._createGUI()
  File "/home/roberto/scipion3/scipion-pyworkflow/pyworkflow/gui/form.py", line 1609, in _createGUI
    paramsFrame = self._createParams(mainFrame)
  File "/home/roberto/scipion3/scipion-pyworkflow/pyworkflow/gui/form.py", line 1988, in _createParams
    contentFrame = self._createSections(paramsFrame)
  File "/home/roberto/scipion3/scipion-pyworkflow/pyworkflow/gui/form.py", line 2034, in _createSections
    self._fillSection(section, frame)
  File "/home/roberto/scipion3/scipion-pyworkflow/pyworkflow/gui/form.py", line 2287, in _fillSection
    widget = ParamWidget(r, paramName, param, self, parent,
  File "/home/roberto/scipion3/scipion-pyworkflow/pyworkflow/gui/form.py", line 997, in __init__
    self.set(value)
  File "/home/roberto/scipion3/scipion-pyworkflow/pyworkflow/gui/form.py", line 1485, in set
    self.var.set(value)
  File "/home/roberto/scipion3/scipion-pyworkflow/pyworkflow/gui/form.py", line 316, in set
    self.tkVar.set(self.enum.choices[value])
TypeError: 'odict_values' object is not subscriptable
