### PR TITLE
CTF consensus merging options

### DIFF
--- a/xmipp3/convert/convert.py
+++ b/xmipp3/convert/convert.py
@@ -40,7 +40,7 @@ except ImportError:
 import numpy as np
 
 from pyworkflow.utils import replaceBaseExt
-from pyworkflow.object import ObjectWrap, String, Float, Integer
+from pyworkflow.object import ObjectWrap, String, Float, Integer, Object
 from pwem.constants import (NO_INDEX, ALIGN_NONE, ALIGN_PROJ, ALIGN_2D,
                             ALIGN_3D)
 from pwem.objects import (Angles, Coordinate, Micrograph, Volume, Particle,
@@ -320,17 +320,22 @@ def setXmippAttributes(obj, objRow, *labels, **kwargs):
             else:
                 value = defaults
 
-            if isinstance(value, int):
-                value = Integer(value)
-            elif isinstance(value, float):
-                value = Float(value)
-            elif isinstance(value, str):
-                value = String(value)
-            else:
-                value = None
+            value = getScipionObj(value)
 
         if value is not None:
             setXmippAttribute(obj, label, value)
+
+def getScipionObj(value):
+    if isinstance(value, Object):
+        return value
+    elif isinstance(value, int):
+        return Integer(value)
+    elif isinstance(value, float):
+        return Float(value)
+    elif isinstance(value, str):
+        return String(value)
+    else:
+        return None
 
 def setXmippAttribute(obj, label, value):
     """ Sets an attribute of an object prefixing it with xmipp"""

--- a/xmipp3/protocols.conf
+++ b/xmipp3/protocols.conf
@@ -8,8 +8,10 @@ Protocols SPA = [
 		{"tag": "protocol", "value": "XmippProtSplitFrames", "text": "default"}	,
 		{"tag": "protocol", "value": "XmippProtMovieGain", "text": "default"}
 	]},
-	{"tag": "section", "text": "Micrographs", "children": [
-		{"tag": "protocol", "value": "XmippProtPreprocessMicrographs", "text": "default"},
+	{"tag": "section", "text": "Micrographs", "openItem": "False", "children": [
+		{"tag": "protocol_group", "text": "Preprocess", "openItem": "False", "children": [
+		    {"tag": "protocol", "value": "XmippProtPreprocessMicrographs", "text": "default"}
+		]},
 		{"tag": "protocol_group", "text": "CTF estimation", "openItem": "False", "children": [
             {"tag": "protocol", "value": "XmippProtCTFMicrographs", "text": "default"},
             {"tag": "protocol", "value": "XmippProtCTFConsensus", "text": "default"}

--- a/xmipp3/viewers/viewer_ctf_consensus.py
+++ b/xmipp3/viewers/viewer_ctf_consensus.py
@@ -81,15 +81,21 @@ class XmippCTFConsensusViewer(ProtocolViewer):
 
     def _visualizeCtfs(self, objName):
         views = []
-        CtfView.PSD_LABELS
+
         # display metadata with selected variables
         labels = ('id enabled _micObj._filename _psdFile _ctf2_psdFile '
                   '_xmipp_ctfmodel_quadrant '
-                  '_defocusU _defocusV _defocus_discrepancy '
+                  '_defocusU _defocusV _ctf2_defocus_diff '
+                  '_astigmatism _ctf2_astigmatism '
+                  '_defocusRatio _ctf2_defocusRatio '
+                  '_defocusAngle _ctf2_defocusAngle_diff '
                   '_resolution _ctf2_resolution _consensus_resolution '
-                  '_defocusAngle _defocusAngle_discrepancy '
-                  '_fitQuality _ctf2_fitQuality '
-                  '_phaseShift _phaseShift_discrepancy')
+                  '_phaseShift _ctf2_phaseShift_diff '
+                  '_fitQuality _ctf2_fitQuality ')
+
+        if self.protocol.useCritXmipp.get():
+            labels += ' '.join(CtfView.EXTRA_LABELS)
+
         if self.protocol.hasAttribute(objName):
             views.append(ObjectView(
                 self._project, self.protocol.strId(),

--- a/xmipp3/viewers/viewer_ctf_consensus.py
+++ b/xmipp3/viewers/viewer_ctf_consensus.py
@@ -81,11 +81,15 @@ class XmippCTFConsensusViewer(ProtocolViewer):
 
     def _visualizeCtfs(self, objName):
         views = []
-
+        CtfView.PSD_LABELS
         # display metadata with selected variables
-        labels = 'id enabled %s _micObj_filename _resolution ' \
-                 '_xmipp_consensus_resolution _xmipp_discrepancy_astigmatism' \
-                 ' _defocusU _defocusV _defocusAngle' % ' '.join(CtfView.PSD_LABELS)
+        labels = ('id enabled _micObj._filename _psdFile _ctf2_psdFile '
+                  '_xmipp_ctfmodel_quadrant '
+                  '_defocusU _defocusV _defocus_discrepancy '
+                  '_resolution _ctf2_resolution _consensus_resolution '
+                  '_defocusAngle _defocusAngle_discrepancy '
+                  '_fitQuality _ctf2_fitQuality '
+                  '_phaseShift _phaseShift_discrepancy')
         if self.protocol.hasAttribute(objName):
             views.append(ObjectView(
                 self._project, self.protocol.strId(),
@@ -148,7 +152,8 @@ class XmippCTFConsensusViewer(ProtocolViewer):
             plotter.plotHist(resolution, nbins=numberOfBins)
             views.append(plotter)
         return views
-    
+
+# TODO: Add histograms using viewer_eliminate_empty_images.plotMultiHistogram()
     
 def getStringIfActive(prot):
     return ', yet.' if prot.isActive() else '.'


### PR DESCRIPTION
Now two options are included when "compute consensus" is activated:

 - 'Average equivalent metadata?': Make an average for defocus and defocusAngle, while computing a new astigmatism and defocusRatio. If not, first CTF defocus information persists.

 -  'Include all secondary metadata?': Append all metadata attributes (not present in first CTF) from the secondary CTF to the resulted one. If not, only metadata from the first (plus some consensus scores like consensus_resolution, ctf2_defocus_diff or ctf2_defocusAngle_diff) is included in the resulted CTF.

Additionally, the viewer is showing mainly those metadata interesting to check the selection/consensus procedure. 