### PR TITLE
Metaprotocol not need protMonitor anymore

### DIFF
--- a/xmipp3/protocols/protocol_metaprotocol_discrete_heterogeneity_scheduler.py
+++ b/xmipp3/protocols/protocol_metaprotocol_discrete_heterogeneity_scheduler.py
@@ -35,7 +35,7 @@ from pyworkflow.project import Manager
 from pyworkflow.protocol import getProtocolFromDb
 import pyworkflow.object as pwobj
 
-from pwem.protocols import ProtMonitor
+from pwem.protocols import EMProtocol
 from pwem.objects import Volume
 
 from xmipp3.protocols import XmippProtSplitVolumeHierarchical
@@ -44,7 +44,7 @@ from xmipp3.protocols import XmippMetaProtCreateOutput
 from xmipp3.protocols import XmippMetaProtCreateSubset
 
 
-class XmippMetaProtDiscreteHeterogeneityScheduler(ProtMonitor):
+class XmippMetaProtDiscreteHeterogeneityScheduler(EMProtocol):
     """ Metaprotocol to run together all the protocols to discover discrete
     heterogeneity in a set of particles
      """
@@ -52,7 +52,7 @@ class XmippMetaProtDiscreteHeterogeneityScheduler(ProtMonitor):
     _lastUpdateVersion = VERSION_2_0
 
     def __init__(self, **kwargs):
-        ProtMonitor.__init__(self, **kwargs)
+        EMProtocol.__init__(self, **kwargs)
         self._runIds = pwobj.CsvList(pType=int)
         self.childs = []
 
@@ -62,7 +62,7 @@ class XmippMetaProtDiscreteHeterogeneityScheduler(ProtMonitor):
                 # child.setAborted()
                 self.getProject().stopProtocol(child)
 
-        ProtMonitor.setAborted(self)
+        EMProtocol.setAborted(self)
 
     def setFailed(self, errorMsg):
         for child in self.childs:
@@ -70,7 +70,7 @@ class XmippMetaProtDiscreteHeterogeneityScheduler(ProtMonitor):
                 # child.setFailed(errorMsg)
                 self.getProject().stopProtocol(child)
 
-        ProtMonitor.setFailed(self, errorMsg)
+        EMProtocol.setFailed(self, errorMsg)
 
     # --------------------------- DEFINE param functions ------------------------
     def _defineParams(self, form):

--- a/xmipp3/protocols/protocol_metaprotocol_golden_highres.py
+++ b/xmipp3/protocols/protocol_metaprotocol_golden_highres.py
@@ -39,14 +39,14 @@ from pyworkflow.protocol.params import (PointerParam, FloatParam, BooleanParam,
 from pyworkflow.project import Manager
 import pyworkflow.object as pwobj
 from pyworkflow.protocol import getProtocolFromDb
-from pwem.protocols import ProtMonitor
+from pwem.protocols import EMProtocol
 from pwem.objects import Volume
 from xmipp3.convert import readSetOfParticles
 from pwem import emlib
 from xmipp3.protocols import XmippProtReconstructHighRes
 
 
-class XmippMetaProtGoldenHighRes(ProtMonitor):
+class XmippMetaProtGoldenHighRes(EMProtocol):
     """ Metaprotocol to run golden version of highres"""
     _label = 'metaprotocol golden highres'
     _lastUpdateVersion = VERSION_2_0
@@ -55,7 +55,7 @@ class XmippMetaProtGoldenHighRes(ProtMonitor):
     SPLIT_OTSU = 1
 
     def __init__(self, **kwargs):
-        ProtMonitor.__init__(self, **kwargs)
+        EMProtocol.__init__(self, **kwargs)
         self._runIds = pwobj.CsvList(pType=int)
         self.childs=[]
 
@@ -65,7 +65,7 @@ class XmippMetaProtGoldenHighRes(ProtMonitor):
                 #child.setAborted()
                 self.getProject().stopProtocol(child)
 
-        ProtMonitor.setAborted(self)
+        EMProtocol.setAborted(self)
 
 
     def setFailed(self, errorMsg):
@@ -74,7 +74,7 @@ class XmippMetaProtGoldenHighRes(ProtMonitor):
                 #child.setFailed(errorMsg)
                 self.getProject().stopProtocol(child)
 
-        ProtMonitor.setFailed(self, errorMsg)
+        EMProtocol.setFailed(self, errorMsg)
 
     #--------------------------- DEFINE param functions ------------------------
     def _defineParams(self, form):


### PR DESCRIPTION
protMonitor will be moved from pwem and I've realized that mateprotocols don't need protMonitor to run, only with EMProtocol is enough.

Scipion team (@pconesa) should consider if having a metaProtocol base class is a good idea, or not. I think yes.

That base class might enclose:
  - setAborted() overrided method 
  - setFailed()  overrided method
  - _updateProtocol() useful method
  - [maybe] insertAllSteps() defining classes list and steps to do.

Well, this ideas above are for future, this Pull Request is much simpler than that.

Please, @ajimoreno check this two protocols still working in this way.