### PR TITLE
adding tests for the metaprotocols

### DIFF
--- a/xmipp3/tests/test_protocols_metaprotocol_golden_highres.py
+++ b/xmipp3/tests/test_protocols_metaprotocol_golden_highres.py
@@ -1,0 +1,96 @@
+# **************************************************************************
+# *
+# * Authors:    Amaya Jimenez Moreno (ajimenez@cnb.csic.es)
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+
+from pyworkflow.tests import BaseTest, DataSet, setupTestProject
+from pwem.protocols import (ProtImportVolumes, ProtImportParticles, exists)
+from xmipp3.protocols import XmippMetaProtGoldenHighRes
+
+
+class TestGoldenHighres(BaseTest):
+    @classmethod
+    def runImportVolume(cls, pattern, samplingRate):
+        """ Run an Import volumes protocol. """
+        cls.protImport = cls.newProtocol(ProtImportVolumes,
+                                         filesPath=pattern,
+                                         samplingRate=samplingRate
+                                         )
+        cls.launchProtocol(cls.protImport)
+        return cls.protImport
+
+    @classmethod
+    def runImportParticles(cls):
+        """ Import Particles.
+        """
+        args = {'importFrom': ProtImportParticles.IMPORT_FROM_SCIPION,
+                'sqliteFile': cls.particles,
+                'amplitudConstrast': 0.1,
+                'sphericalAberration': 2.0,
+                'voltage': 200,
+                'samplingRate': 0.99,
+                'haveDataBeenPhaseFlipped': True
+                }
+
+        # Id's should be set increasing from 1 if ### is not in the 
+        # pattern
+        protImport = cls.newProtocol(ProtImportParticles, **args)
+        protImport.setObjLabel('import particles')
+        cls.launchProtocol(protImport)
+        return protImport
+
+    @classmethod
+    def setUpClass(cls):
+        setupTestProject(cls)
+
+        # Data
+        cls.dataset = DataSet.getDataSet('10010')
+        cls.initialVolume = cls.dataset.getFile('initialVolume')
+        cls.particles = cls.dataset.getFile('particles')
+
+        cls.protImportVol = cls.runImportVolume(cls.initialVolume, 4.95)
+        cls.protImportParts = cls.runImportParticles()
+
+    def test(self):
+        goldenHighres = self.newProtocol(XmippMetaProtGoldenHighRes,
+                                   inputParticles=self.protImportParts.outputParticles,
+                                   inputVolumes=self.protImportVol.outputVolume,
+                                   particleRadius=180,
+                                   symmetryGroup="i1",
+                                   discardParticles=True,
+                                   numberOfMpi=8)
+        self.launchProtocol(goldenHighres)
+        self.assertIsNotNone(goldenHighres.outputParticlesLocal1,
+                             "There was a problem with Golden Highres")
+
+        fnResolution = goldenHighres._getExtraPath('fnFSCs.txt')
+        if not exists(fnResolution):
+            self.assertTrue(False, fnResolution + " does not exist")
+        else:
+            count = len(open(fnResolution).readlines())
+            count = count - 10
+            result = 'outputParticlesLocal%d' % (count)
+            o = getattr(goldenHighres, result, None)
+            locals()[result] = o
+            self.assertIsNotNone(o, "Output: %s is None" % result)

--- a/xmipp3/tests/test_protocols_metaprotocol_heterogeneity.py
+++ b/xmipp3/tests/test_protocols_metaprotocol_heterogeneity.py
@@ -1,0 +1,77 @@
+# **************************************************************************
+# *
+# * Authors:    Amaya Jimenez Moreno (ajimenez@cnb.csic.es)
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+
+from pyworkflow.tests import BaseTest, setupTestProject, DataSet
+from pwem.protocols import ProtImportParticles, ProtImportVolumes, ProtSubSet
+
+from xmipp3.protocols import XmippMetaProtDiscreteHeterogeneityScheduler
+
+
+class TestMetaprotHeterogeneity(BaseTest):
+    @classmethod
+    def setUpClass(cls):
+        setupTestProject(cls)
+        cls.dsRelion = DataSet.getDataSet('relion_tutorial')
+
+    def importVolume(self):
+        prot = self.newProtocol(ProtImportVolumes,
+                                objLabel='import volume',
+                                filesPath=self.dsRelion.getFile(
+                                    'volumes/reference.mrc'),
+                                samplingRate=7.08)
+        self.launchProtocol(prot)
+
+        return prot
+
+    def importParticles(self, path):
+        """ Import an EMX file with Particles and defocus
+        """
+        prot = self.newProtocol(ProtImportParticles,
+                                objLabel='from relion',
+                                importFrom=ProtImportParticles.IMPORT_FROM_RELION,
+                                starFile=self.dsRelion.getFile(path),
+                                magnification=10000,
+                                samplingRate=7.08,
+                                haveDataBeenPhaseFlipped=True)
+        self.launchProtocol(prot)
+
+        return prot
+
+    def test(self):
+        protImportVol = self.importVolume()
+        path = 'import/case2/relion_it015_data.star'
+        protImportParts = self.importParticles(path)
+
+        protHeterogeneity = self.newProtocol(XmippMetaProtDiscreteHeterogeneityScheduler,
+                                           inputVolume=protImportVol.outputVolume,
+                                           inputParticles=protImportParts.outputParticles,
+                                           maxNumClasses=3,
+                                           symmetryGroup='d2',
+                                           numberOfMpi=8)
+        self.launchProtocol(protHeterogeneity)
+        self.assertFalse(protHeterogeneity.isFailed(), 'Metaprotocol Heterogeneity has failed.')
+
+


### PR DESCRIPTION
In this PR I'm adding the tests for metaprotocol_golden_highres and metaprotocol_discrete_heterogeneity. As I said before, for me, the metaprotocol_discrete_heterogeneity is not working because of the python bindings of xmipp. But I still don't know if it is a problem of my configuration or if it is a general problem.