### PR TITLE
use Set id instead of protocol id

### DIFF
--- a/xmipp3/viewers/viewer_ctf_consensus.py
+++ b/xmipp3/viewers/viewer_ctf_consensus.py
@@ -97,9 +97,9 @@ class XmippCTFConsensusViewer(ProtocolViewer):
             labels += ' '.join(CtfView.EXTRA_LABELS)
 
         if self.protocol.hasAttribute(objName):
+            set = getattr(self.protocol, objName)
             views.append(ObjectView(
-                self._project, self.protocol.strId(),
-                getattr(self.protocol, objName).getFileName(),
+                self._project, set.getObjId(),set.getFileName(),
                 viewParams={MODE: MODE_MD, ORDER: labels, VISIBLE: labels}))
         else:
             self.infoMessage('%s does not have %s%s'


### PR DESCRIPTION
This fixes the absence of output when creating a manual CTF subset from a ShowJ that was launched from CTF consensus viewer.