### PR TITLE
Outputs particles in mrcs instead of mrc. So dimensions are right. TO…

### DIFF
--- a/xmipp3/protocols/protocol_extract_particles.py
+++ b/xmipp3/protocols/protocol_extract_particles.py
@@ -230,7 +230,7 @@ class XmippProtExtractParticles(ProtExtractParticles, XmippProtocol):
                 fnCTF = None
 
             args = " -i %s --pos %s" % (fnLast, particlesMd)
-            args += " -o %s.mrc --Xdim %d" % (outputRoot, boxSize)
+            args += " -o %s.mrcs --Xdim %d" % (outputRoot, boxSize)
 
             if doInvert:
                 args += " --invert"
@@ -246,7 +246,7 @@ class XmippProtExtractParticles(ProtExtractParticles, XmippProtocol):
             # Normalize
             if normalizeArgs:
                 self.runJob('xmipp_transform_normalize',
-                            '-i %s.mrc %s' % (outputRoot, normalizeArgs))
+                            '-i %s.mrcs %s' % (outputRoot, normalizeArgs))
         else:
             self.warning("The micrograph %s hasn't coordinate file! "
                          % baseMicName)


### PR DESCRIPTION
…DO: Scipion should be clever to Know that these are 2D objects.