### PR TITLE
Fix tests pc

### DIFF
--- a/xmipp3/tests/test_protocol_deep_denoising.py
+++ b/xmipp3/tests/test_protocol_deep_denoising.py
@@ -47,7 +47,7 @@ class TestDeepDenoising(BaseTest):
                                                inputParticles=self.particles,
                                                imageSize=32)
         self.launchProtocol(trainAndPredictProt)
-        self.assertIsNotEmpty(trainAndPredictProt.outputParticles)
+        self.assertSetSize(trainAndPredictProt.outputParticles, msg="Denoising training +  predict output seems wrong")
 
     def test_only_predict(self):
         self.importData()
@@ -61,4 +61,4 @@ class TestDeepDenoising(BaseTest):
                                        imageSize=32)
         self.launchProtocol(predictProt)
 
-        self.assertIsNotEmpty(predictProt.outputParticles)
+        self.assertSetSize(predictProt.outputParticles, msg="Denoising only predict output seems wrong")

--- a/xmipp3/tests/test_protocols_deepVolPostprocessing.py
+++ b/xmipp3/tests/test_protocols_deepVolPostprocessing.py
@@ -27,6 +27,7 @@ from pwem.protocols import ProtImportVolumes, exists
 from pyworkflow.tests import BaseTest, DataSet, setupTestProject
 
 from xmipp3.protocols import XmippProtDeepVolPostProc, XmippProtCreateMask3D
+from xmipp3.protocols.protocol_postProcessing_deepPostProcessing import POSTPROCESS_VOL_BASENAME
 
 
 class TestDeepVolPostProcessingBase(BaseTest):
@@ -88,5 +89,5 @@ class TestDeepVolPostProcessing(TestDeepVolPostProcessingBase):
                                    normalization= XmippProtDeepVolPostProc.NORMALIZATION_AUTO
                                    )
         self.launchProtocol(deepPostProc)
-        self.assertTrue(exists(deepPostProc._getExtraPath('deepPostProcVol.mrc')),
+        self.assertTrue(exists(deepPostProc._getExtraPath(POSTPROCESS_VOL_BASENAME)),
                         "Deep Volume Postprocessing has failed")


### PR DESCRIPTION
THis PR should fix the DeepX tests.

The expected output mrc file of one of them wasn't matching one created by the protocol

The assertion of the test required a message parameter.