### PR TITLE
show unit cell does not work 

### DIFF
--- a/xmipp3/convert/convert.py
+++ b/xmipp3/convert/convert.py
@@ -1458,7 +1458,10 @@ def alignmentToRow(alignment, alignmentRow, alignType):
         if flip:
             raise Exception("the det of the transformation matrix is "
                             "negative. This is not a valid transformation "
-                            "matrix for Scipion.")
+                            "matrix for Scipion. %s %f"% (str(matrix[0:3, 0:3]),
+                                                          np.linalg.det(matrix[0:3, 0:3])
+                                                         )
+                           )
     shifts, angles = geometryFromMatrix(matrix, inverseTransform)
     alignmentRow.setValue(emlib.MDL_SHIFT_X, shifts[0])
     alignmentRow.setValue(emlib.MDL_SHIFT_Y, shifts[1])

--- a/xmipp3/viewers/viewer_extract_asymmetric_unit.py
+++ b/xmipp3/viewers/viewer_extract_asymmetric_unit.py
@@ -137,7 +137,10 @@ class viewerXmippProtExtractUnit(EmProtocolViewer):
         cMap = ['red', 'yellow', 'green', 'cyan', 'blue']
         d = {}
         d['outerRadius'] = self.protocol.outerRadius.get() * sampling
-        d['innerRadius'] = self.protocol.innerRadius.get() * sampling
+        innerRadius = self.protocol.innerRadius.get()
+        if innerRadius < 0:
+           innerRadius = 0
+        d['innerRadius'] = innerRadius * sampling
         d['symmetry'] = Chimera.getSymmetry(XMIPP_TO_SCIPION[self.protocol.symmetryGroup.get()])
 
         if self.protocol.symmetryGroup >= XMIPP_I222:


### PR DESCRIPTION
Show unit cell does not work. It does not work when  minradius=-1, which is the default value.


 This is partially fixed in @mmmtnez  PR but I like better my  solution since the value of minradius is used in some calculations and should not be -1 but 0