### PR TITLE
Mm model building view

### DIFF
--- a/xmipp3/protocols.conf
+++ b/xmipp3/protocols.conf
@@ -153,8 +153,7 @@ Model building = [
 	{"tag": "protocol", "value": "XmippProtMonoRes",   "text": "default"},
 	{"tag": "protocol", "value": "XmippProtLocSharp",  "text": "default"},
 	{"tag": "protocol", "value": "XmippProtDeepVolPostProc",  "text": "default"},
-	{"tag": "protocol", "value": "XmippProtExtractUnit",   "text": "default"},
-	{"tag": "protocol", "value": "XmippProtConvertPdb",  "text": "default"}
+	{"tag": "protocol", "value": "XmippProtExtractUnit",   "text": "default"}
 	]},
 	{"tag": "section", "text": "Initial model", "icon": "bookmark.png", "children": [
 	]},
@@ -164,6 +163,9 @@ Model building = [
 	]},
 	{"tag": "section", "text": "Validation", "icon": "bookmark.png", "children": [
 	{"tag": "protocol", "value": "XmippProtValFit",   "text": "default"}
+	]},
+	{"tag": "section", "text": "Tools-Calculators", "icon": "bookmark.png", "children": [
+	{"tag": "protocol", "value": "XmippProtConvertPdb",   "text": "xmipp3 - map from atomic structure"}
 	]}]
 
 Random Conical Tilt = [

--- a/xmipp3/viewers/viewer_resolution_monogenic_signal.py
+++ b/xmipp3/viewers/viewer_resolution_monogenic_signal.py
@@ -96,7 +96,7 @@ class XmippMonoResViewer(LocalResolutionViewer):
                        label='Show slice number')
         
         group.addParam('doShowChimera', LabelParam,
-                      label="Show Resolution map in Chimera")
+                      label="Show Resolution map in ChimeraX")
 
         ColorScaleWizardBase.defineColorScaleParams(group, defaultLowest=self.protocol.min_res_init,
                                                     defaultHighest=self.protocol.max_res_init)


### PR DESCRIPTION
Hi all,

here you are a small change in protocols.conf file of xmipp with the aim of relocating the protocol 'xmipp3 - convert PDB' in the menu 'Tools-Calculators' of Model building view, rather than having it in 'Preprocess map'. At the same time, and since PDB will be a confusing word when almost every atomic structure was in mmCIF format, I have also replaced 'convert PDB' by 'map from atomic structure' which, additionally, reports better the functionality of this protocol.