### PR TITLE
Mm sharpening viewers

### DIFF
--- a/xmipp3/protocols.conf
+++ b/xmipp3/protocols.conf
@@ -153,8 +153,7 @@ Model building = [
 	{"tag": "protocol", "value": "XmippProtMonoRes",   "text": "default"},
 	{"tag": "protocol", "value": "XmippProtLocSharp",  "text": "default"},
 	{"tag": "protocol", "value": "XmippProtDeepVolPostProc",  "text": "default"},
-	{"tag": "protocol", "value": "XmippProtExtractUnit",   "text": "default"},
-	{"tag": "protocol", "value": "XmippProtConvertPdb",  "text": "default"}
+	{"tag": "protocol", "value": "XmippProtExtractUnit",   "text": "default"}
 	]},
 	{"tag": "section", "text": "Initial model", "icon": "bookmark.png", "children": [
 	]},
@@ -164,6 +163,9 @@ Model building = [
 	]},
 	{"tag": "section", "text": "Validation", "icon": "bookmark.png", "children": [
 	{"tag": "protocol", "value": "XmippProtValFit",   "text": "default"}
+	]},
+	{"tag": "section", "text": "Tools-Calculators", "icon": "bookmark.png", "children": [
+	{"tag": "protocol", "value": "XmippProtConvertPdb",   "text": "xmipp3 - map from atomic structure"}
 	]}]
 
 Random Conical Tilt = [

--- a/xmipp3/protocols/protocol_extract_asymmetric_unit.py
+++ b/xmipp3/protocols/protocol_extract_asymmetric_unit.py
@@ -147,7 +147,6 @@ class XmippProtExtractUnit(EMProtocol):
     def createOutputStep(self):
         vol = Volume()
         vol.setLocation(self._getOutputVol())
-
         sampling = self.inputVolumes.get().getSamplingRate()
         vol.setSamplingRate(sampling)
         #

--- a/xmipp3/protocols/protocol_extract_asymmetric_unit.py
+++ b/xmipp3/protocols/protocol_extract_asymmetric_unit.py
@@ -147,6 +147,7 @@ class XmippProtExtractUnit(EMProtocol):
     def createOutputStep(self):
         vol = Volume()
         vol.setLocation(self._getOutputVol())
+
         sampling = self.inputVolumes.get().getSamplingRate()
         vol.setSamplingRate(sampling)
         #

--- a/xmipp3/protocols/protocol_postProcessing_deepPostProcessing.py
+++ b/xmipp3/protocols/protocol_postProcessing_deepPostProcessing.py
@@ -253,17 +253,24 @@ class XmippProtDeepVolPostProc(ProtAnalysis3D, xmipp3.XmippProtocol):
         volume.setFileName(self._getExtraPath(POSTPROCESS_VOL_BASENAME))
 
         if self.useHalfMapsInsteadVol.get():
-          if self.halfMapsAttached.get():
-            volume.setSamplingRate(self.inputVolume.get().getSamplingRate())
-          else:
-            volume.setSamplingRate(self.inputHalf1.get().getSamplingRate())
-          self._defineOutputs(Volume=volume)
-          self._defineTransformRelation(self.inputHalf1, volume)
-          self._defineTransformRelation(self.inputHalf2, volume)
+            if self.halfMapsAttached.get():
+                inVol = self.inputVolume.get()
+            else:
+                inVol = self.inputHalf1.get()
+
+            volume.setSamplingRate(inVol.getSamplingRate())
+            volume.setOrigin(inVol.getOrigin(force=True))
+
+            self._defineOutputs(Volume=volume)
+            self._defineTransformRelation(self.inputHalf1, volume)
+            self._defineTransformRelation(self.inputHalf2, volume)
         else:
-          volume.setSamplingRate(self.inputVolume.get().getSamplingRate())
-          self._defineOutputs(Volume=volume)
-          self._defineTransformRelation(self.inputVolume, volume)
+            inVol = self.inputVolume.get()
+            volume.setSamplingRate(inVol.getSamplingRate())
+            volume.setOrigin(inVol.getOrigin(force=True))
+
+            self._defineOutputs(Volume=volume)
+            self._defineTransformRelation(self.inputVolume, volume)
 
 
                 

--- a/xmipp3/protocols/protocol_volume_local_sharpening.py
+++ b/xmipp3/protocols/protocol_volume_local_sharpening.py
@@ -38,7 +38,6 @@ import pwem.emlib.metadata as md
 from pwem.emlib.metadata import (MDL_COST, MDL_ITER, MDL_SCALE)
 from ntpath import dirname
 from os.path import exists
-from pwem.convert import Ccp4Header
 
 LOCALDEBLUR_METHOD_URL='http://github.com/I2PC/scipion/wiki/XmippProtLocSharp' 
 

--- a/xmipp3/protocols/protocol_volume_local_sharpening.py
+++ b/xmipp3/protocols/protocol_volume_local_sharpening.py
@@ -38,6 +38,7 @@ import pwem.emlib.metadata as md
 from pwem.emlib.metadata import (MDL_COST, MDL_ITER, MDL_SCALE)
 from ntpath import dirname
 from os.path import exists
+from pwem.convert import Ccp4Header
 
 LOCALDEBLUR_METHOD_URL='http://github.com/I2PC/scipion/wiki/XmippProtLocSharp' 
 
@@ -271,22 +272,21 @@ class XmippProtLocSharp(ProtAnalysis3D):
              
     def createOutputStep(self):
 
-        volume=Volume()
+        volume = Volume()
         volume.setFileName(self._getExtraPath('sharpenedMap_last.mrc'))
         volume.setSamplingRate(self.inputVolume.get().getSamplingRate())
         volume.setOrigin(self.inputVolume.get().getOrigin(True))
 
-
         volumesSet = self._createSetOfVolumes()
-        volumesSet.setSamplingRate(self.inputVolume.get().getSamplingRate()) 
+        volumesSet.setSamplingRate(self.inputVolume.get().getSamplingRate())
         for i in range(self.iteration):
-            vol = Volume()       
-            vol.setLocation(i, self._getExtraPath('sharpenedMap_%d.mrc' % (i+1)))
-            vol.setObjComment("Sharpened Map, \n Epoch %d"%(i+1))
-            volumesSet.append(vol)  
-            
+            vol = Volume()
+            vol.setLocation(i, self._getExtraPath('sharpenedMap_%d.mrc' % (i + 1)))
+            vol.setObjComment("Sharpened Map, \n Epoch %d" % (i + 1))
+            volumesSet.append(vol)
+
         self._defineOutputs(outputVolumes=volumesSet)
-        self._defineSourceRelation(self.inputVolume, volumesSet)            
+        self._defineSourceRelation(self.inputVolume, volumesSet)
                      
     # --------------------------- INFO functions ------------------------------
 

--- a/xmipp3/viewers/__init__.py
+++ b/xmipp3/viewers/__init__.py
@@ -49,6 +49,8 @@ from .viewer_volume_strain import XmippVolumeStrainViewer
 from .viewer_reconstruct_highres import XmippReconstructHighResViewer
 from .viewer_solid_angles import SolidAnglesViewer
 from .viewer_extract_asymmetric_unit import viewerXmippProtExtractUnit
+from .viewer_deepEMHancer import viewerXmippProtDeepVolPostProc
+from .viewer_local_sharpening import viewerXmippProtLocSharp
 
 
 #from .viewer_combine_pdb import XmippProtCombinePdbViewer

--- a/xmipp3/viewers/viewer_deepEMHancer.py
+++ b/xmipp3/viewers/viewer_deepEMHancer.py
@@ -1,0 +1,134 @@
+# **************************************************************************
+# *
+# * Authors:  Roberto Marabini (roberto@cnb.csic.es), May 2013
+# *           Marta Martinez (mmmtnez@cnb.csic.es)
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+
+import os
+
+from pwem.convert import Ccp4Header
+from pwem.objects import Transform
+from pwem.objects import Volume
+from pwem.emlib.image import ImageHandler
+from pwem.viewers import Chimera, ChimeraView, EmProtocolViewer
+from xmipp3.protocols.protocol_postProcessing_deepPostProcessing import \
+    (XmippProtDeepVolPostProc)
+from pwem.viewers.viewer_chimera import (Chimera, sessionFile)
+from pyworkflow.viewer import DESKTOP_TKINTER, Viewer
+
+class viewerXmippProtDeepVolPostProc(Viewer):
+    """ Visualize the input and output volumes of protocol XmippProtDeepVolPostProc
+        with ChimeraX (3D).
+        The axes of coordinates x, y, z will be shown"""
+    _label = 'viewer deepEMHancer'
+    _targets = [XmippProtDeepVolPostProc]
+    _environments = [DESKTOP_TKINTER]
+
+    # =========================================================================
+    # Show Volumes
+    # =========================================================================
+
+    def _visualize(self, obj, **args):
+        # Input map(s) are a parameter from the protocol
+        dim = 150.
+        sampling = 1.
+        _inputVol = None
+        _inputHalf1 = None
+        _inputHalf2 = None
+        listVol = []
+        directory = self.protocol._getExtraPath()
+
+        if self.protocol.useHalfMapsInsteadVol.get():
+            if self.protocol.halfMapsAttached.get():
+                if self.protocol.inputVolume.get() is not None:
+                    _inputVol = self.protocol.inputVolume.get()
+                    dim = _inputVol.getDim()[0]
+                    sampling = _inputVol.getSamplingRate()
+                    listVol.append(_inputVol)
+            else:
+                if self.protocol.inputHalf1.get() is not None:
+                    _inputHalf1 = self.protocol.inputHalf1.get()
+                    _inputHalf2 = self.protocol.inputHalf2.get()
+                    dim = _inputHalf1.getDim()[0]
+                    sampling = _inputHalf1.getSamplingRate()
+                    listVol.append(_inputHalf1)
+                    listVol.append(_inputHalf2)
+
+        else:
+            if self.protocol.inputVolume.get() is not None:
+                _inputVol = self.protocol.inputVolume.get()
+                dim = _inputVol.getDim()[0]
+                sampling = _inputVol.getSamplingRate()
+                listVol.append(_inputVol)
+        bildFileName = self.protocol._getTmpPath("axis_output.bild")
+        Chimera.createCoordinateAxisFile(dim,
+                                         bildFileName=bildFileName,
+                                         sampling=sampling)
+        fnCxc = self.protocol._getTmpPath("chimera_output.cxc")
+        f = open(fnCxc, 'w')
+        # change to workingDir
+        # If we do not use cd and the project name has an space
+        # the protocol fails even if we pass absolute paths
+        f.write('cd %s\n' % os.getcwd())
+        f.write("open %s\n" % bildFileName)
+        f.write("cofr 0,0,0\n")  # set center of coordinates
+        counter = 1
+        for vol in listVol:
+            counter += 1
+            self._visInputVolume(f, vol, counter)
+        for filename in sorted(os.listdir(directory)):
+            if filename.endswith(".mrc"):
+                counter += 1
+                volFileName = os.path.join(directory, filename)
+                vol = Volume()
+                vol.setFileName(volFileName)
+                if self.protocol.useHalfMapsInsteadVol.get():
+                    if self.protocol.halfMapsAttached.get():
+                        inVol = self.protocol.inputVolume.get()
+                    else:
+                        inVol = self.protocol.inputHalf1.get()
+                else:
+                    inVol = self.protocol.inputVolume.get()
+
+                vol.setSamplingRate(inVol.getSamplingRate())
+                vol.setOrigin(inVol.getOrigin(True))
+
+                self._visInputVolume(f, vol, counter)
+                f.write("volume #%d level %0.3f\n"
+                        % (counter, 0.001))
+
+        f.close()
+
+        return [ChimeraView(fnCxc)]
+
+    def _visInputVolume(self, f, vol, counter):
+        inputVolFileName = ImageHandler.removeFileType(vol.getFileName())
+        f.write("open %s\n" % inputVolFileName)
+        if vol.hasOrigin():
+            x, y, z = vol.getOrigin().getShifts()
+        else:
+            x, y, z = vol.getOrigin(force=True).getShifts()
+        f.write("volume #%d style surface voxelSize %f\n"
+                "volume #%d origin %0.2f,%0.2f,%0.2f\n"
+                % (counter, vol.getSamplingRate(), counter, x, y, z))

--- a/xmipp3/viewers/viewer_deepEMHancer.py
+++ b/xmipp3/viewers/viewer_deepEMHancer.py
@@ -41,7 +41,7 @@ class viewerXmippProtDeepVolPostProc(Viewer):
     """ Visualize the input and output volumes of protocol XmippProtDeepVolPostProc
         with ChimeraX (3D).
         The axes of coordinates x, y, z will be shown"""
-    _label = 'viewer deepEMHancer'
+    _label = 'viewer deepEMhancer'
     _targets = [XmippProtDeepVolPostProc]
     _environments = [DESKTOP_TKINTER]
 

--- a/xmipp3/viewers/viewer_local_sharpening.py
+++ b/xmipp3/viewers/viewer_local_sharpening.py
@@ -1,0 +1,104 @@
+# **************************************************************************
+# *
+# * Authors:  Roberto Marabini (roberto@cnb.csic.es), May 2013
+# *           Marta Martinez (mmmtnez@cnb.csic.es)
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+
+import os
+
+from pwem.convert import Ccp4Header
+from pwem.objects import Transform
+from pwem.objects import Volume
+from pwem.emlib.image import ImageHandler
+from pwem.viewers import Chimera, ChimeraView, EmProtocolViewer
+from xmipp3.protocols.protocol_volume_local_sharpening import \
+    (XmippProtLocSharp)
+from pwem.viewers.viewer_chimera import (Chimera, sessionFile)
+from pyworkflow.viewer import DESKTOP_TKINTER, Viewer
+
+class viewerXmippProtLocSharp(Viewer):
+    """ Visualize the input and output volumes of protocol XmippProtDeepVolPostProc
+        with ChimeraX (3D).
+        The axes of coordinates x, y, z will be shown"""
+    _label = 'viewer local_sharpening'
+    _targets = [XmippProtLocSharp]
+    _environments = [DESKTOP_TKINTER]
+
+    # =========================================================================
+    # Show Volumes
+    # =========================================================================
+
+    def _visualize(self, obj, **args):
+        # Input map(s) are a parameter from the protocol
+        dim = 150.
+        sampling = 1.
+        _inputVol = None
+        directory = self.protocol._getExtraPath()
+
+        if self.protocol.inputVolume.get() is not None:
+            _inputVol = self.protocol.inputVolume.get()
+            dim = _inputVol.getDim()[0]
+            sampling = _inputVol.getSamplingRate()
+        bildFileName = self.protocol._getTmpPath("axis_output.bild")
+        Chimera.createCoordinateAxisFile(dim,
+                                         bildFileName=bildFileName,
+                                         sampling=sampling)
+        fnCxc = self.protocol._getTmpPath("chimera_output.cxc")
+        f = open(fnCxc, 'w')
+        # change to workingDir
+        # If we do not use cd and the project name has an space
+        # the protocol fails even if we pass absolute paths
+        f.write('cd %s\n' % os.getcwd())
+        f.write("open %s\n" % bildFileName)
+        f.write("cofr 0,0,0\n")  # set center of coordinates
+        counter = 2
+        self._visInputVolume(f, _inputVol, counter)
+
+        for filename in sorted(os.listdir(directory)):
+            if filename.endswith("_last.mrc"):
+                counter += 1
+                volFileName = os.path.join(directory, filename)
+                vol = Volume()
+                vol.setFileName(volFileName)
+                vol.setSamplingRate(self.protocol.inputVolume.get().getSamplingRate())
+                vol.setOrigin(self.protocol.inputVolume.get().getOrigin(True))
+
+                self._visInputVolume(f, vol, counter)
+                f.write("volume #%d level %0.3f\n"
+                        % (counter, 0.001))
+
+        f.close()
+
+        return [ChimeraView(fnCxc)]
+
+    def _visInputVolume(self, f, vol, counter):
+        inputVolFileName = ImageHandler.removeFileType(vol.getFileName())
+        f.write("open %s\n" % inputVolFileName)
+        if vol.hasOrigin():
+            x, y, z = vol.getOrigin().getShifts()
+        else:
+            x, y, z = vol.getOrigin(force=True).getShifts()
+        f.write("volume #%d style surface voxelSize %f\n"
+                "volume #%d origin %0.2f,%0.2f,%0.2f\n"
+                % (counter, vol.getSamplingRate(), counter, x, y, z))

--- a/xmipp3/viewers/viewer_resolution_monogenic_signal.py
+++ b/xmipp3/viewers/viewer_resolution_monogenic_signal.py
@@ -96,7 +96,7 @@ class XmippMonoResViewer(LocalResolutionViewer):
                        label='Show slice number')
         
         group.addParam('doShowChimera', LabelParam,
-                      label="Show Resolution map in Chimera")
+                      label="Show Resolution map in ChimeraX")
 
         ColorScaleWizardBase.defineColorScaleParams(group, defaultLowest=self.protocol.min_res_init,
                                                     defaultHighest=self.protocol.max_res_init)


### PR DESCRIPTION
Hi all,

in addition to previous changes, here your are some changes in protocols involved in map sharpening:

    1)  xmipp3/protocols/protocol_postProcessing_deepPostProcessing.py: Inclusion of origin of coordinates.
    2)  xmipp3/protocols/protocol_volume_local_sharpening.py: Typo corrections.
    3)  xmipp3/viewers/__init__.py: Inclusion of two new classes of ChimeraX viewers.
    4)  xmipp3/viewers/viewer_deepEMHancer.py: New ChimeraX viewer for protocol xmipp3/protocols/protocol_postProcessing_deepPostProcessing.py (origin checked).
    5)  xmipp3/viewers/viewer_local_sharpening.py: New ChimeraX viewer for protocol xmipp3/protocols/protocol_volume_local_sharpening.py (origin checked).

Tests:

scipion3 tests xmipp3.tests.test_protocols_localdeblur.TestLocalDeblur
scipion3 tests xmipp3.tests.test_protocols_localdeblur.TestDeepVolPostProcessing

I guess the above test is:
    scipion3 tests xmipp3.tests.test_protocols_deepVolPostprocessing.TestDeepVolPostProcessing
