### PR TITLE
Aj monores half volumes

### DIFF
--- a/xmipp3/viewers/viewer_resolution_monogenic_signal.py
+++ b/xmipp3/viewers/viewer_resolution_monogenic_signal.py
@@ -119,7 +119,7 @@ class XmippMonoResViewer(LocalResolutionViewer):
         return [cm]
     
     def _showOriginalVolumeSlices(self, param=None):
-        if self.protocol.halfVolumes.get() is True:
+        if self.protocol.halfVolumes.get() is True and self.protocol.halfVolumesFile.get() is False:
             cm = DataView(self.protocol.inputVolume.get().getFileName())
             cm2 = DataView(self.protocol.inputVolume2.get().getFileName())
             return [cm, cm2]
@@ -209,7 +209,7 @@ class XmippMonoResViewer(LocalResolutionViewer):
         else:
             fnResVol = self.protocol._getExtraPath(OUTPUT_RESOLUTION_FILE_CHIMERA)
 
-        if self.protocol.halfVolumes.get():
+        if self.protocol.halfVolumes.get() is True and self.protocol.halfVolumesFile.get() is False:
             vol = self.protocol.inputVolume.get()
         else:
             vol = self.protocol.inputVolumes.get()


### PR DESCRIPTION
I have modified MonoRes protocol to allow the option of using the half maps stored in the input volume. I have tried the different options and everything seems to work fine, but take a careful look at it, because I'm not familiar with the details of this protocol.