### PR TITLE
Fix deprecation warnings due to invalid escape sequences.

### DIFF
--- a/xmipp3/__init__.py
+++ b/xmipp3/__init__.py
@@ -144,7 +144,7 @@ class Plugin(pwem.Plugin):
 
         ## Linking bindings (removing installationToken)
         bindingsAndLibsCmd = ("find {bindingsSrc} -maxdepth 1 -mindepth 1 "
-                              "! -name __pycache__ -exec ln -srfn {{}} {bindingsDst} \; && "
+                              r"! -name __pycache__ -exec ln -srfn {{}} {bindingsDst} \; && "
                               "ln -srfn {coreLib} {libsDst} && "
                               "touch {bindingsToken} && "
                               "rm {installedToken} 2> /dev/null")

--- a/xmipp3/bibtex.py
+++ b/xmipp3/bibtex.py
@@ -161,7 +161,7 @@ keywords = "Image processing, Cluster analysis, Neural networks, Self-organizing
 }
 
 @article{PascualMontano2001,
-title = "A Novel Neural Network Technique for Analysis and Classification of \{EM\} Single-Particle Images",
+title = "A Novel Neural Network Technique for Analysis and Classification of \\{EM\\} Single-Particle Images",
 journal = "JSB",
 volume = "133",
 number = "2 - 3",
@@ -318,7 +318,7 @@ author = "Sorzano, C.O.S. and S. Jonic and C. El-Bez and J.M. Carazo and S. De C
 
 @Article{Sorzano2007a,
   Title                    = {Fast, robust and accurate determination of transmission electron microscopy contrast transfer function},
-  Author                   = {Sorzano, C. O. S. and Jonic, S. and N\'u\~nez-Ram\'irez, R. and Boisset, N. and Carazo, J. M.},
+  Author                   = {Sorzano, C. O. S. and Jonic, S. and N\'u\\~nez-Ram\'irez, R. and Boisset, N. and Carazo, J. M.},
   Journal                  = {J. Structural Biology},
   Year                     = {2007},
   Pages                    = {249--262},

--- a/xmipp3/protocols/protocol_mltomo.py
+++ b/xmipp3/protocols/protocol_mltomo.py
@@ -90,7 +90,7 @@ class XmippProtMLTomo(ProtClassify3D):
         self._iterTemplate = self._getFileName('ref_it', iter=0).replace('000000', '??????')
         # Iterations will be identify by _itXXXXXX_ where XXXXXX is the
         # iteration number and is restricted to only 6 digits.
-        self._iterRegex = re.compile('_it(\d{6,6})_')
+        self._iterRegex = re.compile(r'_it(\d{6,6})_')
 
     #--------------------------- DEFINE param functions -----------------------
     def _defineParams(self, form):

--- a/xmipp3/protocols/protocol_projmatch/projmatch_steps.py
+++ b/xmipp3/protocols/protocol_projmatch/projmatch_steps.py
@@ -459,7 +459,7 @@ def insertAngularClassAverageStep(self, iterN, refN, **kwargs):
               'outClasses' : outClasses
               }
     
-    args = ' -i ctfGroup[0-9][0-9][0-9][0-9][0-9][0-9]\$@'
+    args = r' -i ctfGroup[0-9][0-9][0-9][0-9][0-9][0-9]\$@'
     args += '%(docFileInputAngles)s --lib %(projLibraryDoc)s -o %(outClasses)s'
     
     # FIXME: This option no exist in the form

--- a/xmipp3/protocols/protocol_screen_deeplearning.py
+++ b/xmipp3/protocols/protocol_screen_deeplearning.py
@@ -223,7 +223,7 @@ class XmippProtScreenDeepLearning(ProtProcessParticles, XmippProtocol):
           elif fname== self._getExtraPath("testFalseParticlesSet.xmd"):
             return self.testNegSetOfParticles.get()
           else:
-            matchOjb= re.match( self._getExtraPath("negativeSet_(\d+).xmd"), fname)
+            matchOjb= re.match( self._getExtraPath(r"negativeSet_(\d+).xmd"), fname)
             if matchOjb:
               num= matchOjb.group(1)
               return self.__dict__["negativeSet_%s"%num].get()

--- a/xmipp3/viewers/viewer_resolution_fso.py
+++ b/xmipp3/viewers/viewer_resolution_fso.py
@@ -464,7 +464,7 @@ class XmippProtFSOViewer(ProtocolViewer):
         return colors
     
     def getColorMap(self):
-        if (COLOR_CHOICES[self.colorMap.get()] is 'other'): 
+        if (COLOR_CHOICES[self.colorMap.get()] == 'other'):
             cmap = cm.get_cmap(self.otherColorMap.get())
         else:
             cmap = cm.get_cmap(COLOR_CHOICES[self.colorMap.get()])


### PR DESCRIPTION
Fixes #328 . Fixes below warnings : 

```
find . -iname '*.py' | xargs -P4 -I{} python3 -Wall -m py_compile {} 
./xmipp3/viewers/viewer_resolution_fso.py:467: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if (COLOR_CHOICES[self.colorMap.get()] is 'other'):
./xmipp3/protocols/protocol_screen_deeplearning.py:226: DeprecationWarning: invalid escape sequence \d
  matchOjb= re.match( self._getExtraPath("negativeSet_(\d+).xmd"), fname)
./xmipp3/protocols/protocol_projmatch/projmatch_steps.py:462: DeprecationWarning: invalid escape sequence \$
  args = ' -i ctfGroup[0-9][0-9][0-9][0-9][0-9][0-9]\$@'
./xmipp3/protocols/protocol_mltomo.py:93: DeprecationWarning: invalid escape sequence \d
  self._iterRegex = re.compile('_it(\d{6,6})_')
./xmipp3/bibtex.py:27: DeprecationWarning: invalid escape sequence \{
  """
./xmipp3/__init__.py:147: DeprecationWarning: invalid escape sequence \;
  "! -name __pycache__ -exec ln -srfn {{}} {bindingsDst} \; && "
```