### PR TITLE
use an "indirect" pointer to mics in ctf set. This should fix pointer…

### DIFF
--- a/xmipp3/protocols/protocol_ctf_consensus.py
+++ b/xmipp3/protocols/protocol_ctf_consensus.py
@@ -34,7 +34,7 @@ from math import radians, degrees
 
 from pyworkflow import VERSION_2_0
 from pwem.objects import SetOfCTF, SetOfMicrographs
-from pyworkflow.object import Set, Integer
+from pyworkflow.object import Set, Integer, Pointer
 import pyworkflow.protocol.params as params
 import pyworkflow.utils as pwutils
 
@@ -358,7 +358,12 @@ class XmippProtCTFConsensus(ProtCTFMicrographs):
 
         # We have finished when there is not more input ctf (stream closed)
         # and the number of processed ctf is equal to the number of inputs
-        self.finished = (self.isStreamClosed and allDone == len(self.allCtf1))
+        if self.calculateConsensus:
+            maxCtfSize = min(len(self.allCtf1), len(self.allCtf2))
+        else:
+            maxCtfSize = len(self.allCtf1)
+
+        self.finished = (self.isStreamClosed and allDone == maxCtfSize)
 
         streamMode = Set.STREAM_CLOSED if self.finished else Set.STREAM_OPEN
 
@@ -388,8 +393,14 @@ class XmippProtCTFConsensus(ProtCTFMicrographs):
         def updateRelationsAndClose(cSet, mSet, first, label=''):
 
             if os.path.exists(self._getPath('ctfs'+label+'.sqlite')):
+
+                micsAttrName = 'outputMicrographs'+label
+                self._updateOutputSet(micsAttrName, mSet, streamMode)
+                # Set micrograph as pointer to protocol to prevent pointee end up as another attribute (String, Booelan,...)
+                # that happens somewhere while scheduling.
+                cSet.setMicrographs(Pointer(self, extended=micsAttrName))
+
                 self._updateOutputSet('outputCTF'+label, cSet, streamMode)
-                self._updateOutputSet('outputMicrographs'+label, mSet, streamMode)
 
                 if first:
                     self._defineTransformRelation(self.inputCTF.get().getMicrographs(),


### PR DESCRIPTION
… being "moved" to the wrong attribute.

Also, consider different size of ctf sets as input (double consensus where first has discarded some ctfs)

Hi, this should fix 2 couple of issues. Is up to you if you want this sent to master or devel.

I started from master since to me it is a "hotfix"