### PR TITLE
1 scipion3 mm tmp toextra

### DIFF
--- a/xmipp3/utils.py
+++ b/xmipp3/utils.py
@@ -30,7 +30,7 @@ This module contains utils functions for Xmipp protocols
 
 from os.path import join
 import numpy as np
-import pyvista as pv
+# import pyvista as pv
 
 from pyworkflow import Config
 from pwem import emlib

--- a/xmipp3/viewers/viewer_deepEMHancer.py
+++ b/xmipp3/viewers/viewer_deepEMHancer.py
@@ -81,11 +81,11 @@ class viewerXmippProtDeepVolPostProc(Viewer):
                 dim = _inputVol.getDim()[0]
                 sampling = _inputVol.getSamplingRate()
                 listVol.append(_inputVol)
-        bildFileName = self.protocol._getTmpPath("axis_output.bild")
+        bildFileName = self.protocol._getExtraPath("axis_output.bild")
         Chimera.createCoordinateAxisFile(dim,
                                          bildFileName=bildFileName,
                                          sampling=sampling)
-        fnCxc = self.protocol._getTmpPath("chimera_output.cxc")
+        fnCxc = self.protocol._getExtraPath("chimera_output.cxc")
         f = open(fnCxc, 'w')
         # change to workingDir
         # If we do not use cd and the project name has an space

--- a/xmipp3/viewers/viewer_extract_asymmetric_unit.py
+++ b/xmipp3/viewers/viewer_extract_asymmetric_unit.py
@@ -87,8 +87,8 @@ class viewerXmippProtExtractUnit(EmProtocolViewer):
             return self._showVolumesXmipp()
 
     def _createSetOfVolumes(self):
-        if not exists(self.protocol._getTmpPath('tmpVolumes.sqlite')):
-            tmpFileName = self.protocol._getTmpPath("tmpVolumes.sqlite")
+        if not exists(self.protocol._getExtraPath('tmpVolumes.sqlite')):
+            tmpFileName = self.protocol._getExtraPath("tmpVolumes.sqlite")
             _inputVol = self.protocol.inputVolumes.get()
             _outputVol = self.protocol.outputVolume
             setOfVolumes = SetOfVolumes(filename=tmpFileName)
@@ -96,16 +96,16 @@ class viewerXmippProtExtractUnit(EmProtocolViewer):
             setOfVolumes.append(_outputVol)
             setOfVolumes.write()
         else:
-            tmpFileName = self.protocol._getTmpPath('tmpVolumes.sqlite')
+            tmpFileName = self.protocol._getExtraPath('tmpVolumes.sqlite')
             setOfVolumes = SetOfVolumes(filename=tmpFileName)
         return setOfVolumes
 
     def _showVolumesChimera(self):
-        tmpFileNameCMD = self.protocol._getTmpPath("chimera.cxc")
+        tmpFileNameCMD = self.protocol._getExtraPath("chimera.cxc")
         f = open(tmpFileNameCMD, "w")
         dim = self.protocol.inputVolumes.get().getDim()[0]
         sampling = self.protocol.inputVolumes.get().getSamplingRate()
-        tmpFileName = os.path.abspath(self.protocol._getTmpPath("axis.bild"))
+        tmpFileName = os.path.abspath(self.protocol._getExtraPath("axis.bild"))
         Chimera.createCoordinateAxisFile(dim,
                                  bildFileName=tmpFileName,
                                  sampling=sampling)

--- a/xmipp3/viewers/viewer_local_sharpening.py
+++ b/xmipp3/viewers/viewer_local_sharpening.py
@@ -60,11 +60,11 @@ class viewerXmippProtLocSharp(Viewer):
             _inputVol = self.protocol.inputVolume.get()
             dim = _inputVol.getDim()[0]
             sampling = _inputVol.getSamplingRate()
-        bildFileName = self.protocol._getTmpPath("axis_output.bild")
+        bildFileName = self.protocol._getExtraPath("axis_output.bild")
         Chimera.createCoordinateAxisFile(dim,
                                          bildFileName=bildFileName,
                                          sampling=sampling)
-        fnCxc = self.protocol._getTmpPath("chimera_output.cxc")
+        fnCxc = self.protocol._getExtraPath("chimera_output.cxc")
         f = open(fnCxc, 'w')
         # change to workingDir
         # If we do not use cd and the project name has an space


### PR DESCRIPTION
Hi all,

here you have a small change affecting the visualization with ChimeraX in viewer_extract_asymmetric_unit, viewer_deepEMhancer y viewer_local_sharpening. Since the tmp folder has been removed from Scipion, now the cxc files that ChimeraX opens have been saved in the extra folder. However, still I have a problem with the visualization from slices in viewer_extract_asymmetric_unit that I do not know how to solve. Here you have the error:

Exception in Tkinter callback
Traceback (most recent call last):
  File "/usr/lib/python3.6/tkinter/__init__.py", line 1705, in __call__
    return self.func(*args)
  File "/home/marta/software/scipion3/scipion-pyworkflow/pyworkflow/gui/form.py", line 1281, in _visualizeVar
    self.visualizeCallback(self.paramName)
  File "/home/marta/software/scipion3/scipion-pyworkflow/pyworkflow/viewer.py", line 265, in _visualizeParam
    views = self._getVisualizeDict()[paramName](paramName)
  File "/home/marta/software/scipion3/xmipp-bundle/src/scipion-em-xmipp/xmipp3/viewers/viewer_extract_asymmetric_unit.py", line 87, in _showVolumes
    return self._showVolumesXmipp()
  File "/home/marta/software/scipion3/xmipp-bundle/src/scipion-em-xmipp/xmipp3/viewers/viewer_extract_asymmetric_unit.py", line 166, in _showVolumesXmipp
    setOfVolumes = self._createSetOfVolumes()
  File "/home/marta/software/scipion3/xmipp-bundle/src/scipion-em-xmipp/xmipp3/viewers/viewer_extract_asymmetric_unit.py", line 96, in _createSetOfVolumes
    setOfVolumes.append(_outputVol)
  File "/home/marta/software/scipion3/scipion-em/pwem/objects/data.py", line 1037, in append
    EMSet.append(self, image)
  File "/home/marta/software/scipion3/scipion-pyworkflow/pyworkflow/object.py", line 1233, in append
    self._insertItem(item)
  File "/home/marta/software/scipion3/scipion-pyworkflow/pyworkflow/object.py", line 1237, in _insertItem
    self._getMapper().insert(item)
  File "/home/marta/software/scipion3/scipion-pyworkflow/pyworkflow/mapper/sqlite.py", line 767, in insert
    *obj.getObjDict().values())
  File "/home/marta/software/scipion3/scipion-pyworkflow/pyworkflow/mapper/sqlite.py", line 1185, in insertObject
    self.executeCommand(self.INSERT_OBJECT, args)
sqlite3.ProgrammingError: Incorrect number of bindings supplied. The current statement uses 9, and there are 11 supplied.


