### PR TITLE
Bringing the re-compiling avoiding (from master) to devel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     # For a discussion on single-sourcing the version across setup.py and the
     # project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='20.07.03',  # Required
+    version='20.07.04',  # Required
 
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:

--- a/xmipp3/__init__.py
+++ b/xmipp3/__init__.py
@@ -176,6 +176,7 @@ class Plugin(pwem.Plugin):
                            deps=xmippDeps, default=False)
 
         avoidConfig = os.environ.get('XMIPP_NOCONFIG', 'False') == 'True'
+        alreadyCompiled = os.path.isfile(getXmippPath('v'+_currentVersion))  # compilation token (see the xmipp script)
         configSrc = ('./xmipp check_config' if avoidConfig
                      else './xmipp config noAsk && ./xmipp check_config')
         env.addPackage('xmippSrc', version=_currentVersion,
@@ -187,7 +188,7 @@ class Plugin(pwem.Plugin):
                                   installTgt + sourceTgt),
                                  (bindingsAndLibsCmd.format(**installVars),
                                   bindingsAndLibsTgt)],
-                       deps=xmippDeps, default=not develMode)
+                       deps=xmippDeps, default=not (develMode or alreadyCompiled))
 
         ## EXTRA PACKAGES ##
         installDeepLearningToolkit(cls, env)


### PR DESCRIPTION
Sorry, this is the last PR regarding this flash release, I guess.

This is to avoid to destroy an eventual xmipp.conf (manually set in the past) when updating the scipion-em-xmipp plugin, by default. Users always can force the bundle re-installation. Already in master.