### PR TITLE
Fix test relaignment classes: Use EmanProtAutopick instead of SparksG…

### DIFF
--- a/xmipp3/tests/test_protocols_realignment_classes.py
+++ b/xmipp3/tests/test_protocols_realignment_classes.py
@@ -31,9 +31,9 @@ from xmipp3.protocols.protocol_center_particles import *
 
 ProtCTFFind = Domain.importFromPlugin('cistem.protocols', 'CistemProtCTFFind',
                                       doRaise=True)
-SparxGaussianProtPicking = Domain.importFromPlugin('eman2.protocols',
-                                                   'SparxGaussianProtPicking',
-                                                   doRaise=True)
+EmanProtAutopick = Domain.importFromPlugin('eman2.protocols',
+                                                   'EmanProtAutopick',
+                                           doRaise=True)
 
 
 # Number of mics to be processed
@@ -81,10 +81,11 @@ class TestCenterParticles(BaseTest):
 
     def runPicking(self, inputMicrographs):
         """ Run a particle picking. """
-        protPicking = SparxGaussianProtPicking(boxSize=64,
-                                               numberOfThreads=1,
-                                               numberOfMpi=1,
-                                               lowerThreshold=0.001)
+        protPicking = EmanProtAutopick(boxSize=64,
+                                       numberOfThreads=1,
+                                       numberOfMpi=1,
+                                       boxerMode=3,
+                                       gaussLow=0.001)
         protPicking.inputMicrographs.set(inputMicrographs)
         self.launchProtocol(protPicking)
 


### PR DESCRIPTION
…aussianProtPicking.

This command runs de test:

scipion3 test xmipp3.tests.test_protocols_realignment_classes