### PR TITLE
Multiple threads allowed

### DIFF
--- a/xmipp3/tests/test_protocol_deepConsensusTesting.py
+++ b/xmipp3/tests/test_protocol_deepConsensusTesting.py
@@ -98,7 +98,7 @@ class TestXmippProtScreenDeepConsensusBigTest(BaseTest):
                            "There was a problem with the consensus")
       return prot
 
-    def getDeepConsensusKwargs(self, case=1, metacase=1):
+    def getDeepConsensusKwargs(self, case=1, inputCase=1):
       kwargs = {
         'nEpochs' : 1.0,
         'nModels' :2,
@@ -106,15 +106,17 @@ class TestXmippProtScreenDeepConsensusBigTest(BaseTest):
         'trainingBatch':3,
         'predictingBatch':3
       }
-      metacaseKwargs = {'numberOfThreads': 1} if metacase<4 else {'numberOfThreads': 4}
-      if metacase in [1, 4]:
-        metacaseKwargs['modelInitialization'] = ADD_MODEL_TRAIN_NEW
-      elif metacase in [2, 5]:
-        metacaseKwargs['modelInitialization'] = ADD_MODEL_TRAIN_PRETRAIN
-      elif metacase in [3, 6]:
-        metacaseKwargs['modelInitialization'] = ADD_MODEL_TRAIN_PREVRUN
-        metacaseKwargs['continueRun'] = self.lastRun
+      #inputCase controls the input model of the protocol: previous protocol model, new model, pretrained
+      inputCaseKwargs = {'numberOfThreads': 1} if inputCase<4 else {'numberOfThreads': 4}
+      if inputCase in [1, 4]:
+        inputCaseKwargs['modelInitialization'] = ADD_MODEL_TRAIN_NEW
+      elif inputCase in [2, 5]:
+        inputCaseKwargs['modelInitialization'] = ADD_MODEL_TRAIN_PRETRAIN
+      elif inputCase in [3, 6]:
+        inputCaseKwargs['modelInitialization'] = ADD_MODEL_TRAIN_PREVRUN
+        inputCaseKwargs['continueRun'] = self.lastRun
 
+      #case controls the behavior of the protocol. e.g: skip training, do preliminar predictions
       if case == 1:
         caseKwargs = {'doPreliminarPredictions': False, 'skipTraining': False}
       elif case == 2:
@@ -128,34 +130,37 @@ class TestXmippProtScreenDeepConsensusBigTest(BaseTest):
         caseKwargs={}
 
       kwargs.update(caseKwargs)
-      kwargs.update(metacaseKwargs)
+      kwargs.update(inputCaseKwargs)
       return kwargs
 
-    def testDeepConsensusNew2Thread(self):
+    def testDeepConsensusNew(self):
+      #Testing the protocol on new model
       nCoordinateSets = 3
-      metacase, case = 4, 3
+      inputCase, case = 4, 3
 
       inpCoords = self.prepareInput(case, nCoordinateSets)
-      kwargs = self.getDeepConsensusKwargs(case, metacase)
+      kwargs = self.getDeepConsensusKwargs(case, inputCase)
       self.lastRun = self._runDeepConsensusPicking(inpCoords, kwargs, case)
 
-    def testDeepConsensusPretrain2Thread(self):
+    def testDeepConsensusPretrain(self):
+      #Testing the protocol on pretrained model
       nCoordinateSets = 3
-      metacase, case = 5, 1
+      inputCase, case = 5, 1
 
       inpCoords = self.prepareInput(case, nCoordinateSets)
-      kwargs = self.getDeepConsensusKwargs(case, metacase)
+      kwargs = self.getDeepConsensusKwargs(case, inputCase)
       self.lastRun = self._runDeepConsensusPicking(inpCoords, kwargs, case)
 
-    def testDeepConsensusPrevRun2Thread(self):
+    def testDeepConsensusPrevRun(self):
+      #Testing the protocol on a model from a previous run
       nCoordinateSets = 3
-      metacase, case = 6, 4
+      inputCase, case = 6, 4
 
       inpCoords = self.prepareInput(case, nCoordinateSets)
-      prev_kwargs = self.getDeepConsensusKwargs(case=2, metacase=5)
+      prev_kwargs = self.getDeepConsensusKwargs(case=2, inputCase=5)
       self.lastRun = self._runDeepConsensusPicking(inpCoords, prev_kwargs, case)
 
-      kwargs = self.getDeepConsensusKwargs(case, metacase)
+      kwargs = self.getDeepConsensusKwargs(case, inputCase)
       self._runDeepConsensusPicking(inpCoords, kwargs, case)
 
 

--- a/xmipp3/tests/test_protocol_deepConsensusTesting.py
+++ b/xmipp3/tests/test_protocol_deepConsensusTesting.py
@@ -134,63 +134,24 @@ class TestXmippProtScreenDeepConsensusBigTest(BaseTest):
     def testDeepConsensusNew2Thread(self):
       nCoordinateSets = 3
       metacase, case = 4, 3
-      protImpMics = self._runInportMicrographs()
-      protImpCoords = self._runImportCoordinates(protImpMics, case)
 
-      protsStreamCoords = []
-      for i in range(nCoordinateSets):
-        protsStreamCoords.append(self._runStreamCoordinates(protImpCoords, i))
-
-      for i in range(nCoordinateSets):
-        self._waitOutput(protsStreamCoords[i], "outputCoordinates")
-
-      inpCoords = []
-      for prot in protsStreamCoords:
-        point = Pointer(prot, extended="outputCoordinates")
-        inpCoords.append(point)
+      inpCoords = self.prepareInput(case, nCoordinateSets)
       kwargs = self.getDeepConsensusKwargs(case, metacase)
-
       self.lastRun = self._runDeepConsensusPicking(inpCoords, kwargs, case)
 
     def testDeepConsensusPretrain2Thread(self):
       nCoordinateSets = 3
       metacase, case = 5, 1
-      protImpMics = self._runInportMicrographs()
-      protImpCoords = self._runImportCoordinates(protImpMics, case)
 
-      protsStreamCoords = []
-      for i in range(nCoordinateSets):
-        protsStreamCoords.append(self._runStreamCoordinates(protImpCoords, i))
-
-      for i in range(nCoordinateSets):
-        self._waitOutput(protsStreamCoords[i], "outputCoordinates")
-
-      inpCoords = []
-      for prot in protsStreamCoords:
-        point = Pointer(prot, extended="outputCoordinates")
-        inpCoords.append(point)
+      inpCoords = self.prepareInput(case, nCoordinateSets)
       kwargs = self.getDeepConsensusKwargs(case, metacase)
-
       self.lastRun = self._runDeepConsensusPicking(inpCoords, kwargs, case)
 
     def testDeepConsensusPrevRun2Thread(self):
       nCoordinateSets = 3
       metacase, case = 6, 4
-      protImpMics = self._runInportMicrographs()
-      protImpCoords = self._runImportCoordinates(protImpMics, case)
 
-      protsStreamCoords = []
-      for i in range(nCoordinateSets):
-        protsStreamCoords.append(self._runStreamCoordinates(protImpCoords, i))
-
-      for i in range(nCoordinateSets):
-        self._waitOutput(protsStreamCoords[i], "outputCoordinates")
-
-      inpCoords = []
-      for prot in protsStreamCoords:
-        point = Pointer(prot, extended="outputCoordinates")
-        inpCoords.append(point)
-
+      inpCoords = self.prepareInput(case, nCoordinateSets)
       prev_kwargs = self.getDeepConsensusKwargs(case=2, metacase=5)
       self.lastRun = self._runDeepConsensusPicking(inpCoords, prev_kwargs, case)
 
@@ -212,5 +173,22 @@ class TestXmippProtScreenDeepConsensusBigTest(BaseTest):
         if not prot.hasAttribute(outputName):
           return False
       return True
+
+    def prepareInput(self, case, nCoordSets=3):
+      protImpMics = self._runInportMicrographs()
+      protImpCoords = self._runImportCoordinates(protImpMics, case)
+
+      protsStreamCoords = []
+      for i in range(nCoordSets):
+        protsStreamCoords.append(self._runStreamCoordinates(protImpCoords, i))
+
+      for i in range(nCoordSets):
+        self._waitOutput(protsStreamCoords[i], "outputCoordinates")
+
+      inpCoords = []
+      for prot in protsStreamCoords:
+        point = Pointer(prot, extended="outputCoordinates")
+        inpCoords.append(point)
+      return inpCoords
 
 

--- a/xmipp3/tests/test_protocol_screen_deepConsensus.py
+++ b/xmipp3/tests/test_protocol_screen_deepConsensus.py
@@ -143,7 +143,7 @@ class TestXmippProtScreenDeepConsensus(BaseTest):
       return kwargs
 
 
-    def testImportCoordinates(self):
+    def testDeepConsensus(self):
       nCoordinateSets = 3
       protImpMics = self._runInportMicrographs()
 


### PR DESCRIPTION
Couple of changes which avoid  concurrency and fix most of the errors encountered in a deep testing checking:
- 1 thread vs 2 threads
- new model vs pretrained vs previous run
- skip vs not skip training
- do vs don't do preliminar predictions