### PR TITLE
Highres changed its default resolution criterion and that is why the …

### DIFF
--- a/xmipp3/tests/test_protocols_highres.py
+++ b/xmipp3/tests/test_protocols_highres.py
@@ -88,6 +88,7 @@ class TestHighres(BaseTest):
                                    inputVolumes=self.protImportVol.outputVolume,
                                    particleRadius=180,
                                    symmetryGroup="i1",
+                                   nextResolutionCriterion=0.143,
                                    alignmentMethod=XmippProtReconstructHighRes.AUTOMATIC_ALIGNMENT,
                                    maximumTargetResolution="15 10 7",
                                    numberOfMpi=8)


### PR DESCRIPTION
…test was not passing