### PR TITLE
Zernike programs: replace .vol by .mrc, improving tests stability

### DIFF
--- a/xmipp3/protocols/protocol_apply_deformation_zernike3d.py
+++ b/xmipp3/protocols/protocol_apply_deformation_zernike3d.py
@@ -1,5 +1,6 @@
 # # *************************************************
 # # * This protocol will be offered in future releases (more testing is needed)
+# # * TODO: If this protocol is added, check that sampling rate is properly set in header of mrc
 # # *************************************************
 
 # # **************************************************************************
@@ -76,7 +77,7 @@
 #             with open(file, 'w') as fid:
 #                 fid.write(' '.join(map(str, basisParams)) + "\n")
 #                 fid.write(' '.join(map(str, coeffs)) + "\n")
-#             outFile = pwutils.removeBaseExt(self.inputVol.get().getFileName()) + '_%d_deformed.vol' % idx
+#             outFile = pwutils.removeBaseExt(self.inputVol.get().getFileName()) + '_%d_deformed.mrc' % idx
 #             params = ' -i %s --clnm %s -o %s' % \
 #                      (self.inputVol.get().getFileName(), file, self._getExtraPath(outFile))
 #             self.runJob("xmipp_volume_apply_deform_sph", params)
@@ -101,7 +102,7 @@
 #
 #     def _updateClass(self, item):
 #         representative = item.getRepresentative()
-#         volumeFile = pwutils.removeBaseExt(self.inputVol.get().getFileName()) + '_%d_deformed.vol' \
+#         volumeFile = pwutils.removeBaseExt(self.inputVol.get().getFileName()) + '_%d_deformed.mrc' \
 #                      % (item.getObjId() + 1)
 #         volumeFile = self._getExtraPath(volumeFile)
 #         representative.setSamplingRate(self.samplingRate_Volume)

--- a/xmipp3/protocols/protocol_structure_map_zernike3d.py
+++ b/xmipp3/protocols/protocol_structure_map_zernike3d.py
@@ -84,8 +84,8 @@ class XmippProtStructureMapZernike3D(ProtAnalysis3D):
     """ Protocol for structure mapping based on Zernike3D. """
     _label = 'struct map - Zernike3D'
     _lastUpdateVersion = VERSION_2_0
-    OUTPUT_SUFFIX = '_%d_crop.vol'
-    ALIGNED_VOL = 'vol%dAligned.vol'
+    OUTPUT_SUFFIX = '_%d_crop.mrc'
+    ALIGNED_VOL = 'vol%dAligned.mrc'
 
     def __init__(self, **args):
         ProtAnalysis3D.__init__(self, **args)
@@ -241,11 +241,11 @@ class XmippProtStructureMapZernike3D(ProtAnalysis3D):
                                                             + self.OUTPUT_SUFFIX % (i + 1)))
         else:
             fnOut_aux = self._getTmpPath(self.ALIGNED_VOL % (i + 1))
-        refVolFn = self._getTmpPath("reference_%d.vol" % step_id)
-        fnOut = self._getTmpPath("input_%d.vol" % step_id)
+        refVolFn = self._getTmpPath("reference_%d.mrc" % step_id)
+        fnOut = self._getTmpPath("input_%d.mrc" % step_id)
         copyFile(refVolFn_aux, refVolFn)
         copyFile(fnOut_aux, fnOut)
-        fnOut2 = self._getTmpPath('vol%dDeformedTo%d.vol' % (i + 1, j + 1))
+        fnOut2 = self._getTmpPath('vol%dDeformedTo%d.mrc' % (i + 1, j + 1))
 
         params = ' -i %s -r %s -o %s --l1 %d --l2 %d --sigma "%s" --oroot %s --regularization %f' %\
                  (fnOut, refVolFn, fnOut2, self.l1.get(), self.l2.get(), self.sigma.get(),
@@ -266,7 +266,7 @@ class XmippProtStructureMapZernike3D(ProtAnalysis3D):
         cleanPath(fnOut2)
 
     def deformationMatrix(self, volList):
-        cleanPath(self._getTmpPath("*.vol"))
+        cleanPath(self._getTmpPath("*.mrc"))
         numVol = len(volList)
         self.distanceMatrix = np.zeros((numVol, numVol))
         for i in range(numVol):

--- a/xmipp3/protocols/protocol_volume_deform_zernike3d.py
+++ b/xmipp3/protocols/protocol_volume_deform_zernike3d.py
@@ -156,7 +156,7 @@ class XmippProtVolumeDeformZernike3D(ProtAnalysis3D):
 
     def convertOutputStep(self):
         fnOutVol = self._getFileName('fnOutVol')
-        params = ' -i %s --sampling_rate %.2f' % (fnOutVol, self.newTs)
+        params = ' -i %s --sampling_rate %f' % (fnOutVol, self.newTs)
         self.runJob("xmipp_image_header", params)
 
     def createOutputStep(self):

--- a/xmipp3/protocols/protocol_volume_deform_zernike3d.py
+++ b/xmipp3/protocols/protocol_volume_deform_zernike3d.py
@@ -93,12 +93,13 @@ class XmippProtVolumeDeformZernike3D(ProtAnalysis3D):
     # --------------------------- INSERT steps functions -----------------------
     def _insertAllSteps(self):
         self._createFilenameTemplates()
-        self._insertFunctionStep("convertStep")
-        self._insertFunctionStep("deformStep")
-        self._insertFunctionStep("createOutputStep")
+        self._insertFunctionStep(self.convertInputStep)
+        self._insertFunctionStep(self.deformStep)
+        self._insertFunctionStep(self.convertOutputStep)
+        self._insertFunctionStep(self.createOutputStep)
 
     # --------------------------- STEPS functions ------------------------------
-    def convertStep(self):
+    def convertInputStep(self):
         fnInputVol = self._getFileName('fnInputVol')
         fnRefVol = self._getFileName('fnRefVol')
 
@@ -153,6 +154,10 @@ class XmippProtVolumeDeformZernike3D(ProtAnalysis3D):
                 params = params + ' --thr %d' % self.numberOfThreads.get()
             self.runJob("xmipp_volume_deform_sph", params)
 
+    def convertOutputStep(self):
+        fnOutVol = self._getFileName('fnOutVol')
+        params = ' -i %s --sampling_rate %.2f' % (fnOutVol, self.newTs)
+        self.runJob("xmipp_image_header", params)
 
     def createOutputStep(self):
         if self.targetResolution.get() != 3.0:

--- a/xmipp3/protocols/protocol_volume_deform_zernike3d.py
+++ b/xmipp3/protocols/protocol_volume_deform_zernike3d.py
@@ -82,11 +82,11 @@ class XmippProtVolumeDeformZernike3D(ProtAnalysis3D):
     def _createFilenameTemplates(self):
         """ Centralize how files are called """
         myDict = {
-            'fnRefVol': self._getExtraPath('ref_volume.vol'),
-            'fnInputVol': self._getExtraPath('input_volume.vol'),
-            'fnInputFilt': self._getExtraPath('input_volume_filt.vol'),
-            'fnRefFilt': self._getExtraPath('ref_volume_filt.vol'),
-            'fnOutVol': self._getExtraPath('vol1DeformedTo2.vol')
+            'fnRefVol': self._getExtraPath('ref_volume.mrc'),
+            'fnInputVol': self._getExtraPath('input_volume.mrc'),
+            'fnInputFilt': self._getExtraPath('input_volume_filt.mrc'),
+            'fnRefFilt': self._getExtraPath('ref_volume_filt.mrc'),
+            'fnOutVol': self._getExtraPath('vol1DeformedTo2.mrc')
                  }
         self._updateFilenamesDict(myDict)
 

--- a/xmipp3/tests/test_protocols_zernike3d.py
+++ b/xmipp3/tests/test_protocols_zernike3d.py
@@ -145,8 +145,8 @@ class TestProtocolsZernike3D(TestZernike3DBase):
         self.assertEqual(clnm_gold[0], clnm_test[0], "There is a problem with Zernike degree")
         self.assertEqual(clnm_gold[1], clnm_test[1], "There is a problem with Spherical Harmonics degree")
         self.assertEqual(clnm_gold[2], clnm_test[2], "There is a problem with sphere radius")
-        diff_clnm = np.abs(np.sum(clnm_gold[3] - clnm_test[3]))
-        self.assertAlmostEqual(diff_clnm, 0, delta=0.2,
+        diff_clnm = np.sqrt(np.sum((clnm_gold[3] - clnm_test[3]) ** 2) / clnm_gold[3].size)
+        self.assertAlmostEqual(diff_clnm, 0, delta=0.5,
                                msg="Zernike coefficients do not have the expected value")
 
     def testPairAlignmentZernike3DGPU(self):
@@ -169,8 +169,8 @@ class TestProtocolsZernike3D(TestZernike3DBase):
         self.assertEqual(clnm_gold[0], clnm_test[0], "There is a problem with Zernike degree")
         self.assertEqual(clnm_gold[1], clnm_test[1], "There is a problem with Spherical Harmonics degree")
         self.assertEqual(clnm_gold[2], clnm_test[2], "There is a problem with sphere radius")
-        diff_clnm = np.abs(np.sum(clnm_gold[3] - clnm_test[3]))
-        self.assertAlmostEqual(diff_clnm, 0, delta=0.2,
+        diff_clnm = np.sqrt(np.sum((clnm_gold[3] - clnm_test[3]) ** 2) / clnm_gold[3].size)
+        self.assertAlmostEqual(diff_clnm, 0, delta=0.5,
                                msg="Zernike coefficients do not have the expected value")
 
     def testStructMapZernike3DCPU(self):
@@ -190,22 +190,22 @@ class TestProtocolsZernike3D(TestZernike3DBase):
                                      delimiter=' ')
         sm_test_def = np.loadtxt(structureMap._getExtraPath('CoordinateMatrix3.txt'),
                                      delimiter=' ')
-        diff_sm_def = np.abs(np.sum(sm_gold_def - sm_test_def))
-        self.assertAlmostEqual(diff_sm_def, 0, delta=0.2,
+        diff_sm_def = np.sqrt(np.sum((sm_gold_def - sm_test_def) ** 2) / sm_gold_def.size)
+        self.assertAlmostEqual(diff_sm_def, 0, delta=0.5,
                                msg="Unexpected deformation structure mapping")
         sm_cpu_gold_corr = np.loadtxt(self.dataset.getFile('gold_standard_sm/CPU/CoordinateMatrixCorr3.txt'),
                                      delimiter=' ')
         sm_cpu_test_corr = np.loadtxt(structureMap._getExtraPath(self.CORR_FILE),
                                      delimiter=' ')
-        diff_sm_corr = np.abs(np.sum(sm_cpu_gold_corr - sm_cpu_test_corr))
-        self.assertAlmostEqual(diff_sm_corr, 0, delta=0.2,
+        diff_sm_corr = np.sqrt(np.sum((sm_cpu_gold_corr - sm_cpu_test_corr) ** 2) / sm_cpu_gold_corr.size)
+        self.assertAlmostEqual(diff_sm_corr, 0, delta=0.5,
                                msg=self.EXPECTED_CORR_MAP)
         sm_cpu_gold_cons = np.loadtxt(self.dataset.getFile('gold_standard_sm/CPU/ConsensusMatrix3.txt'),
                                      delimiter=' ')
         sm_cpu_test_cons = np.loadtxt(structureMap._getExtraPath('ConsensusMatrix3.txt'),
                                      delimiter=' ')
-        diff_sm_cons = np.abs(np.sum(sm_cpu_gold_cons - sm_cpu_test_cons))
-        self.assertAlmostEqual(diff_sm_cons, 0, delta=0.2,
+        diff_sm_cons = np.sqrt(np.sum((sm_cpu_gold_cons - sm_cpu_test_cons) ** 2) / sm_cpu_gold_cons.size)
+        self.assertAlmostEqual(diff_sm_cons, 0, delta=0.5,
                                msg="Unexpected consensus structure mapping")
 
     def testStructMapCPU(self):
@@ -222,8 +222,8 @@ class TestProtocolsZernike3D(TestZernike3DBase):
                                      delimiter=' ')
         sm_cpu_test_corr = np.loadtxt(structureMap._getExtraPath(self.CORR_FILE),
                                      delimiter=' ')
-        diff_sm_corr = np.abs(np.sum(sm_cpu_gold_corr - sm_cpu_test_corr))
-        self.assertAlmostEqual(diff_sm_corr, 0, delta=0.2,
+        diff_sm_corr = np.sqrt(np.sum((sm_cpu_gold_corr - sm_cpu_test_corr) ** 2) / sm_cpu_gold_corr.size)
+        self.assertAlmostEqual(diff_sm_corr, 0, delta=0.5,
                                msg=self.EXPECTED_CORR_MAP)
 
 
@@ -244,22 +244,22 @@ class TestProtocolsZernike3D(TestZernike3DBase):
                                      delimiter=' ')
         sm_test_def = np.loadtxt(structureMap._getExtraPath('CoordinateMatrix3.txt'),
                                      delimiter=' ')
-        diff_sm_def = np.abs(np.sum(sm_gold_def - sm_test_def))
-        self.assertAlmostEqual(diff_sm_def, 0, delta=0.2,
+        diff_sm_def = np.sqrt(np.sum((sm_gold_def - sm_test_def) ** 2) / sm_gold_def.size)
+        self.assertAlmostEqual(diff_sm_def, 0, delta=0.5,
                                msg="Unexpected deformation structure mapping")
         sm_cpu_gold_corr = np.loadtxt(self.dataset.getFile('gold_standard_sm/GPU/CoordinateMatrixCorr3.txt'),
                                      delimiter=' ')
         sm_cpu_test_corr = np.loadtxt(structureMap._getExtraPath(self.CORR_FILE),
                                      delimiter=' ')
-        diff_sm_corr = np.abs(np.sum(sm_cpu_gold_corr - sm_cpu_test_corr))
-        self.assertAlmostEqual(diff_sm_corr, 0, delta=0.2,
+        diff_sm_corr = np.sqrt(np.sum((sm_cpu_gold_corr - sm_cpu_test_corr) ** 2) / sm_cpu_gold_corr.size)
+        self.assertAlmostEqual(diff_sm_corr, 0, delta=0.5,
                                msg=self.EXPECTED_CORR_MAP)
         sm_cpu_gold_cons = np.loadtxt(self.dataset.getFile('gold_standard_sm/GPU/ConsensusMatrix3.txt'),
                                      delimiter=' ')
         sm_cpu_test_cons = np.loadtxt(structureMap._getExtraPath('ConsensusMatrix3.txt'),
                                      delimiter=' ')
-        diff_sm_cons = np.abs(np.sum(sm_cpu_gold_cons - sm_cpu_test_cons))
-        self.assertAlmostEqual(diff_sm_cons, 0, delta=0.2,
+        diff_sm_cons = np.sqrt(np.sum((sm_cpu_gold_cons - sm_cpu_test_cons) ** 2) / sm_cpu_gold_cons.size)
+        self.assertAlmostEqual(diff_sm_cons, 0, delta=0.5,
                                msg="Unexpected consensus structure mapping")
 
     def testAngularAlignZernike3DCPU(self):
@@ -279,8 +279,8 @@ class TestProtocolsZernike3D(TestZernike3DBase):
         # Check if coefficients are fine
         aa_gold_clnm = self.readMetadata(self.dataset.getFile('gold_standard_aa/CPU/output_particles.xmd'))
         aa_test_clnm = self.readMetadata(alignZernike._getExtraPath('output_particles.xmd'))
-        diff_clnm = np.abs(np.sum(aa_gold_clnm - aa_test_clnm))
-        self.assertAlmostEqual(diff_clnm, 0, delta=0.2,
+        diff_clnm = np.sqrt(np.sum((aa_gold_clnm - aa_test_clnm) ** 2) / aa_gold_clnm.size)
+        self.assertAlmostEqual(diff_clnm, 0, delta=0.5,
                                msg="Unexpected Zernike coefficients")
 
     def testAngularAlignZernike3DGPU(self):
@@ -300,6 +300,6 @@ class TestProtocolsZernike3D(TestZernike3DBase):
         # Check if coefficients are fine
         aa_gold_clnm = self.readMetadata(self.dataset.getFile('gold_standard_aa/GPU/output_particles.xmd'))
         aa_test_clnm = self.readMetadata(alignZernike._getExtraPath('output_particles.xmd'))
-        diff_clnm = np.abs(np.sum(aa_gold_clnm - aa_test_clnm))
-        self.assertAlmostEqual(diff_clnm, 0, delta=4,
+        diff_clnm = np.sqrt(np.sum((aa_gold_clnm - aa_test_clnm) ** 2) / aa_gold_clnm.size)
+        self.assertAlmostEqual(diff_clnm, 0, delta=0.5,
                                msg="Unexpected Zernike coefficients")


### PR DESCRIPTION
Zernike programs now generate output and intermediate volumes in `.mrc` format instead of `.vol`.

Tests stability of Zernike programs has also been improved.