### PR TITLE
ShiFt Particles protocol: read output xmd properly + compute center of mass of input volume

### DIFF
--- a/xmipp3/protocols/protocol_shift_particles.py
+++ b/xmipp3/protocols/protocol_shift_particles.py
@@ -26,13 +26,15 @@
 # *
 # **************************************************************************
 
-from pyworkflow.protocol.params import PointerParam, BooleanParam, IntParam, EnumParam
+from pwem.emlib.image import ImageHandler as ih
+from pwem.objects import Volume
+from pyworkflow.protocol.params import PointerParam, BooleanParam, IntParam, EnumParam, FloatParam
 from pyworkflow.protocol.constants import LEVEL_ADVANCED
 import pyworkflow.object as pwobj
 from pwem import ALIGN_3D, ALIGN_2D
 import pwem.emlib.metadata as md
 from pwem.protocols import EMProtocol
-from xmipp3.convert import xmippToLocation, writeSetOfParticles
+from xmipp3.convert import xmippToLocation, writeSetOfParticles, readSetOfParticles
 
 
 class XmippProtShiftParticles(EMProtocol):
@@ -46,13 +48,19 @@ class XmippProtShiftParticles(EMProtocol):
         form.addSection(label='Input')
         form.addParam('inputParticles', PointerParam, pointerClass='SetOfParticles', label="Particles",
                       help='Select the SetOfParticles with transformation matrix to be shifted.')
+        form.addParam('option', BooleanParam, label='Select position in volume?', default='True',
+                      help='Select the position where the particles will be shifted in a volume displayed in a wizard.')
         form.addParam('inputVol', PointerParam, pointerClass='Volume', label="Volume", allowsNull=True,
-                      help='Volume to select the point (by clicking in the wizard for selecting the new center) that '
-                           'will be the new center of the particles.')
-        form.addParam('x', IntParam, label="x", help='Use the wizard to select by clicking in the volume the new '
-                                                     'center for the shifted particles')
-        form.addParam('y', IntParam, label="y")
-        form.addParam('z', IntParam, label="z")
+                      condition='option', help='Volume to select the point (by clicking in the wizard for selecting the'
+                                               ' new center) that will be the new center of the particles.')
+        form.addParam('xin', FloatParam, label="x", condition='option',
+                      help='Use the wizard to select the new center for the shifted particles by shift+click on the '
+                           'blue point a drag it to the desired location while pressing shift.')
+        form.addParam('yin', FloatParam, label="y", condition='option')
+        form.addParam('zin', FloatParam, label="z", condition='option')
+        form.addParam('inputMask', PointerParam, pointerClass='VolumeMask', label="Volume mask", allowsNull=True,
+                      condition='not option', help='3D mask to compute the center of mass, the particles will be '
+                                                   'shifted to the computed center of mass')
         form.addParam('boxSizeBool', BooleanParam, label='Use original box size for the shifted particles?',
                       default='True', help='Use input particles box size for the shifted particles.')
         form.addParam('boxSize', IntParam, label='Final box size', condition='not boxSizeBool',
@@ -60,7 +68,7 @@ class XmippProtShiftParticles(EMProtocol):
         form.addParam('inv', BooleanParam, label='Inverse', expertLevel=LEVEL_ADVANCED, default='True',
                       help='Use inverse transformation matrix')
         form.addParam('interp', EnumParam, default=0, choices=['Linear', 'Spline'], expertLevel=LEVEL_ADVANCED,
-                      display=EnumParam.DISPLAY_HLIST , label='Interpolation',
+                      display=EnumParam.DISPLAY_HLIST, label='Interpolation',
                       help='Linear: Use bilinear/trilinear interpolation\nSpline: Use spline interpolation')
 
     # --------------------------- INSERT steps functions --------------------------------------------
@@ -77,14 +85,31 @@ class XmippProtShiftParticles(EMProtocol):
 
     def shiftStep(self):
         """call xmipp program to shift the particles"""
-        program = "xmipp_transform_geometry"
         centermd = self._getExtraPath("center_particles.xmd")
+        args = '-i "%s" -o "%s" ' % (self._getExtraPath("input_particles.xmd"), centermd)
+        if self.option:
+            self.x = self.xin.get()
+            self.y = self.yin.get()
+            self.z = self.zin.get()
+        else:
+            fnvol = self.inputMask.get().getFileName()
+            if fnvol.endswith('.mrc'):
+                fnvol += ':mrc'
+            vol = Volume()
+            vol.setFileName(fnvol)
+            vol = ih().read(vol.getFileName())
+            masscenter = vol.centerOfMass()
+            self.x = masscenter[0]
+            self.y = masscenter[1]
+            self.z = masscenter[2]
+
+        args += '--shift_to %f %f %f ' % (self.x, self.y, self.z)
+        program = "xmipp_transform_geometry"
         if not self.interp.get():
             interp = 'linear'
         else:
             interp = 'spline'
-        args = '-i "%s" -o "%s" --shift_to %f %f %f --apply_transform --dont_wrap --interp %s' % \
-               (self._getExtraPath("input_particles.xmd"), centermd, self.x.get(), self.y.get(), self.z.get(), interp)
+        args += ' --apply_transform --dont_wrap --interp %s' % interp
         if self.inv.get():
             args += ' --inverse'
         self.runJob(program, args)
@@ -104,12 +129,11 @@ class XmippProtShiftParticles(EMProtocol):
             outputmd = self._getExtraPath("center_particles.xmd")
         else:
             outputmd = self._getExtraPath("crop_particles.xmd")
-        outputSet.copyItems(inputParticles, updateItemCallback=self._updateItem,
-                            itemDataIterator=md.iterRows(outputmd))
+        readSetOfParticles(outputmd, outputSet)
         self._defineOutputs(outputParticles=outputSet)
-        self._defineOutputs(shiftX=pwobj.Float(self.x.get()),
-                            shiftY=pwobj.Float(self.y.get()),
-                            shiftZ=pwobj.Float(self.z.get()))
+        self._defineOutputs(shiftX=pwobj.Float(self.x),
+                            shiftY=pwobj.Float(self.y),
+                            shiftZ=pwobj.Float(self.z))
         self._defineSourceRelation(inputParticles, outputSet)
 
     # --------------------------- INFO functions --------------------------------------------
@@ -118,27 +142,24 @@ class XmippProtShiftParticles(EMProtocol):
         if not hasattr(self, 'outputParticles'):
             summary.append("Output particles not ready yet.")
         else:
+            if self.option:
+                option = "User defined shift"
+            else:
+                option = "Shift to center of mass"
             if not self.interp.get():
                 interp = 'linear'
             else:
                 interp = 'spline'
-            summary.append("%d particles shifted\ninterpolation: %s" % (self.inputParticles.get().getSize(), interp))
+            summary.append("%s\ninterpolation: %s" % (option, interp))
             if self.inv.get():
                 summary.append("inverse matrix applied")
         return summary
 
     def _methods(self):
-        return ["%d particles shifted to x = %d, y = %d, z = %d." % (self.inputParticles.get().getSize(),
-                                                                     self.x.get(), self.y.get(), self.z.get())]
+        return []
 
     def _validate(self):
         for part in self.inputParticles.get().iterItems():
             if not part.hasTransform():
                 validatemsg = ['Please provide particles which have transformation matrix.']
                 return validatemsg
-
-    # --------------------------- UTLIS functions --------------------------------------------
-    def _updateItem(self, item, row):
-        newFn = row.getValue(md.MDL_IMAGE)
-        newLoc = xmippToLocation(newFn)
-        item.setLocation(newLoc)

--- a/xmipp3/protocols/protocol_shift_particles.py
+++ b/xmipp3/protocols/protocol_shift_particles.py
@@ -155,9 +155,6 @@ class XmippProtShiftParticles(EMProtocol):
                 summary.append("inverse matrix applied")
         return summary
 
-    def _methods(self):
-        return []
-
     def _validate(self):
         for part in self.inputParticles.get().iterItems():
             if not part.hasTransform():


### PR DESCRIPTION
fix read output xmd properly, improve help and define center by computing center of mass of an input volume. To do that, centerOfMass function from xmipp has been added to python binding in https://github.com/I2PC/xmipp/pull/474