### PR TITLE
Shift Volume protocol: new protocol to shift volumes

### DIFF
--- a/xmipp3/protocols.conf
+++ b/xmipp3/protocols.conf
@@ -149,7 +149,8 @@ Protocols SPA = [
 			{"tag": "protocol", "value": "XmippProtImageOperateVolumes", "text": "default"},
 		    {"tag": "protocol", "value": "XmippProtVolSubtraction", "text": "default"},
 		    {"tag": "protocol", "value": "XmippProtVolAdjust", "text": "default"},
-            {"tag": "protocol", "value": "XmippProtVolConsensus", "text": "default"}
+            {"tag": "protocol", "value": "XmippProtVolConsensus", "text": "default"},
+            {"tag": "protocol", "value": "XmippProtShiftVolume", "text": "default"}
 		]}
 	]}]
 

--- a/xmipp3/protocols/__init__.py
+++ b/xmipp3/protocols/__init__.py
@@ -100,6 +100,7 @@ from .protocol_screen_particles import XmippProtScreenParticles
 from .protocol_screen_deepConsensus import XmippProtScreenDeepConsensus, XmippProtDeepConsSubSet
 from .protocol_screen_deeplearning import XmippProtScreenDeepLearning
 from .protocol_shift_particles import XmippProtShiftParticles
+from .protocol_shift_volume import XmippProtShiftVolume
 from .protocol_simulate_ctf import XmippProtSimulateCTF
 from .protocol_solid_angles import XmippProtSolidAngles
 from .protocol_split_volume import XmippProtSplitvolume

--- a/xmipp3/protocols/protocol_shift_volume.py
+++ b/xmipp3/protocols/protocol_shift_volume.py
@@ -45,9 +45,10 @@ class XmippProtShiftVolume(EMProtocol):
                       help='Use output shifts of protocol "shift particles" which should be executed previously')
         form.addParam('inputProtocol', PointerParam, pointerClass='XmippProtShiftParticles', allowsNull=True,
                       label="Shift particles protocol", condition='shiftBool')
-        form.addParam('x', FloatParam, label="x", condition='not shiftBool', allowsNull=True)
-        form.addParam('y', FloatParam, label="y", condition='not shiftBool', allowsNull=True)
-        form.addParam('z', FloatParam, label="z", condition='not shiftBool', allowsNull=True)
+        COND = 'not shiftBool'
+        form.addParam('x', FloatParam, label="x", condition=COND, allowsNull=True)
+        form.addParam('y', FloatParam, label="y", condition=COND, allowsNull=True)
+        form.addParam('z', FloatParam, label="z", condition=COND, allowsNull=True)
         form.addParam('boxSizeBool', BooleanParam, label='Use original box size for the shifted volume?',
                       default='True', help='Use input volume box size for the shifted volume.')
         form.addParam('boxSize', IntParam, label='Final box size', condition='not boxSizeBool',

--- a/xmipp3/protocols/protocol_shift_volume.py
+++ b/xmipp3/protocols/protocol_shift_volume.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+# **************************************************************************
+# *
+# * Authors:     Estrella Fernandez Gimenez (me.fernandez@cnb.csic.es)
+# *
+# *  BCU, Centro Nacional de Biotecnologia, CSIC
+# *
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+
+from pyworkflow.protocol.params import PointerParam, FloatParam, BooleanParam, IntParam
+import pyworkflow.object as pwobj
+from pwem.protocols import EMProtocol
+from pwem.objects import Volume
+
+
+class XmippProtShiftVolume(EMProtocol):
+    """ This protocol shifts a volume according to the input shifts"""
+
+    _label = 'shift volume'
+
+    # --------------------------- DEFINE param functions --------------------------------------------
+    def _defineParams(self, form):
+        form.addSection(label='Input')
+        form.addParam('inputVol', PointerParam, pointerClass='Volume', label="Volume", help='Volume to shift')
+        form.addParam('shiftBool', BooleanParam, label='Use the same shifts as for the particles?', default='True',
+                      help='Use output shifts of protocol "shift particles" which should be executed previously')
+        form.addParam('inputProtocol', PointerParam, pointerClass='XmippProtShiftParticles', allowsNull=True,
+                      label="Shift particles protocol", condition='shiftBool')
+        form.addParam('x', FloatParam, label="x", condition='not shiftBool', allowsNull=True)
+        form.addParam('y', FloatParam, label="y", condition='not shiftBool', allowsNull=True)
+        form.addParam('z', FloatParam, label="z", condition='not shiftBool', allowsNull=True)
+        form.addParam('boxSizeBool', BooleanParam, label='Use original box size for the shifted volume?',
+                      default='True', help='Use input volume box size for the shifted volume.')
+        form.addParam('boxSize', IntParam, label='Final box size', condition='not boxSizeBool',
+                      help='Box size of the shifted volume.')
+
+    # --------------------------- INSERT steps functions --------------------------------------------
+    def _insertAllSteps(self):
+        self._insertFunctionStep('shiftStep')
+        self._insertFunctionStep('createOutputStep')
+
+    # --------------------------- STEPS functions --------------------------------------------
+    def shiftStep(self):
+        fnVol = self.inputVol.get().getFileName()
+        if not self.boxSizeBool:
+            box = self.boxSize.get()
+            self.runJob('xmipp_transform_window', '-i "%s" -o "%s" --size %d %d %d' %
+                        (fnVol, self._getExtraPath("resized_volume.mrc"), box, box, box))
+            fnVol = self._getExtraPath("resized_volume.mrc")
+        if self.shiftBool:
+            shiftprot = self.inputProtocol.get()
+            self.shiftx = shiftprot.shiftX.get()
+            self.shifty = shiftprot.shiftY.get()
+            self.shiftz = shiftprot.shiftZ.get()
+        else:
+            self.shiftx = self.x.get()
+            self.shifty = self.y.get()
+            self.shiftz = self.z.get()
+        program = "xmipp_transform_geometry"
+        args = '-i %s -o %s --shift %f %f %f --dont_wrap' % \
+               (fnVol, self._getExtraPath("shift_volume.mrc"), self.shiftx, self.shifty, self.shiftz)
+        self.runJob(program, args)
+
+    def createOutputStep(self):
+        out_vol = Volume()
+        in_vol = self.inputVol.get()
+        out_vol.setSamplingRate(in_vol.getSamplingRate())
+        out_vol.setFileName(self._getExtraPath("shift_volume.mrc"))
+        self._defineOutputs(outputVolume=out_vol)
+        self._defineOutputs(shiftX=pwobj.Float(self.shiftx),
+                            shiftY=pwobj.Float(self.shifty),
+                            shiftZ=pwobj.Float(self.shiftz))
+        self._defineSourceRelation(in_vol, out_vol)
+
+    # --------------------------- INFO functions --------------------------------------------
+    def _summary(self):
+        summary = []
+        if not hasattr(self, 'outputVolume'):
+            summary.append("Output volume not ready yet.")
+        else:
+            if self.shiftBool:
+                summary.append("Volume shift as particles in %s" % self.inputProtocol.get())
+            else:
+                summary.append("User defined shift")
+        return summary

--- a/xmipp3/tests/test_protocols_xmipp_3d.py
+++ b/xmipp3/tests/test_protocols_xmipp_3d.py
@@ -1350,6 +1350,12 @@ class TestXmippShiftParticlesAndVolume(TestXmippBase):
         cls.vol1 = cls.dataset.getFile('volumes/volume_1_iter_002.mrc')
 
     def testXmippShiftParticlesAndVolume(self):
+
+        ERROR_SIZE_PART = "There was a problem with the size of output set of particles"
+        ERROR_DIM = "There was a problem with the dimensions of output "
+        ERROR_SR = "There was a problem with the sampling rate value of output "
+        ERROR_SHIFT = "There was a problem with output shift "
+
         protImportVol = self.newProtocol(ProtImportVolumes,
                                           objLabel='Volume',
                                           filesPath=self.vol1,
@@ -1372,15 +1378,13 @@ class TestXmippShiftParticlesAndVolume(TestXmippBase):
         self.launchProtocol(protShiftParticles)
         self.assertIsNotNone(protShiftParticles.getFiles(),
                              "There was a problem with shift particles")
-        self.assertEqual(protShiftParticles.outputParticles.getSamplingRate(), 7.08,
-                         "There was a problem with the sampling rate value of output particles")
+        self.assertEqual(protShiftParticles.outputParticles.getSamplingRate(), 7.08, (ERROR_SR, "particles"))
         self.assertEqual(protShiftParticles.outputParticles.getFirstItem().getDim(), (64, 64, 1),
-                         "There was a problem with the dimensions of output particles")
-        self.assertEqual(protShiftParticles.outputParticles.getSize(), 181,
-                         "There was a problem with the dimensions of output particles")
-        self.assertEqual(protShiftParticles.shiftX.get(), 2.0, "There was a problem with output shift x")
-        self.assertEqual(protShiftParticles.shiftY.get(), 3.0, "There was a problem with output shift y")
-        self.assertEqual(protShiftParticles.shiftZ.get(), 4.0, "There was a problem with output shift z")
+                         (ERROR_DIM, "particles"))
+        self.assertEqual(protShiftParticles.outputParticles.getSize(), 181, ERROR_SIZE_PART)
+        self.assertEqual(protShiftParticles.shiftX.get(), 2.0, (ERROR_SHIFT, "x"))
+        self.assertEqual(protShiftParticles.shiftY.get(), 3.0, (ERROR_SHIFT, "y"))
+        self.assertEqual(protShiftParticles.shiftZ.get(), 4.0, (ERROR_SHIFT, "z"))
 
         protCreateMask = self.newProtocol(XmippProtCreateMask3D,
                                           inputVolume=protImportVol.outputVolume,
@@ -1396,15 +1400,13 @@ class TestXmippShiftParticlesAndVolume(TestXmippBase):
         self.launchProtocol(protShiftParticlesCenterOfMass)
         self.assertIsNotNone(protShiftParticlesCenterOfMass.getFiles(),
                              "There was a problem with shift particles to center of mass")
-        self.assertEqual(protShiftParticlesCenterOfMass.outputParticles.getSamplingRate(), 7.08,
-                         "There was a problem with the sampling rate value of output particles")
+        self.assertEqual(protShiftParticlesCenterOfMass.outputParticles.getSamplingRate(), 7.08, (ERROR_SR, "particles"))
         self.assertEqual(protShiftParticlesCenterOfMass.outputParticles.getFirstItem().getDim(), (64, 64, 1),
-                         "There was a problem with the dimensions of output particles")
-        self.assertEqual(protShiftParticlesCenterOfMass.outputParticles.getSize(), 181,
-                         "There was a problem with the dimensions of output particles")
-        self.assertEqual(protShiftParticlesCenterOfMass.shiftX.get(), 32.0, "There was a problem with output shift x")
-        self.assertEqual(protShiftParticlesCenterOfMass.shiftY.get(), 32.0, "There was a problem with output shift y")
-        self.assertEqual(protShiftParticlesCenterOfMass.shiftZ.get(), 32.0, "There was a problem with output shift z")
+                         (ERROR_DIM, "particles"))
+        self.assertEqual(protShiftParticlesCenterOfMass.outputParticles.getSize(), 181, ERROR_SIZE_PART)
+        self.assertEqual(protShiftParticlesCenterOfMass.shiftX.get(), 32.0, (ERROR_SHIFT, "x"))
+        self.assertEqual(protShiftParticlesCenterOfMass.shiftY.get(), 32.0, (ERROR_SHIFT, "y"))
+        self.assertEqual(protShiftParticlesCenterOfMass.shiftZ.get(), 32.0, (ERROR_SHIFT, "z"))
 
         protShiftVolPart = self.newProtocol(XmippProtShiftVolume,
                                             inputVol=protImportVol.outputVolume,
@@ -1412,13 +1414,11 @@ class TestXmippShiftParticlesAndVolume(TestXmippBase):
         self.launchProtocol(protShiftVolPart)
         self.assertIsNotNone(protShiftVolPart.getFiles(),
                              "There was a problem with shift volume with particle shifts")
-        self.assertEqual(protShiftVolPart.outputVolume.getSamplingRate(), 7.08,
-                         "There was a problem with the sampling rate value of output volume")
-        self.assertEqual(protShiftVolPart.outputVolume.getDim(), (64, 64, 64),
-                         "There was a problem with the dimensions of output volume")
-        self.assertEqual(protShiftVolPart.shiftX.get(), 2.0, "There was a problem with output shift x")
-        self.assertEqual(protShiftVolPart.shiftY.get(), 3.0, "There was a problem with output shift y")
-        self.assertEqual(protShiftVolPart.shiftZ.get(), 4.0, "There was a problem with output shift z")
+        self.assertEqual(protShiftVolPart.outputVolume.getSamplingRate(), 7.08, (ERROR_SR, "volume"))
+        self.assertEqual(protShiftVolPart.outputVolume.getDim(), (64, 64, 64), (ERROR_DIM, "volume"))
+        self.assertEqual(protShiftVolPart.shiftX.get(), 2.0, (ERROR_SHIFT, "x"))
+        self.assertEqual(protShiftVolPart.shiftY.get(), 3.0, (ERROR_SHIFT, "y"))
+        self.assertEqual(protShiftVolPart.shiftZ.get(), 4.0, (ERROR_SHIFT, "z"))
 
         protShiftVolCrop = self.newProtocol(XmippProtShiftVolume,
                                             inputVol=protImportVol.outputVolume,
@@ -1429,13 +1429,11 @@ class TestXmippShiftParticlesAndVolume(TestXmippBase):
         self.launchProtocol(protShiftVolCrop)
         self.assertIsNotNone(protShiftVolCrop.getFiles(),
                              "There was a problem with shift crop volume")
-        self.assertEqual(protShiftVolCrop.outputVolume.getSamplingRate(), 7.08,
-                         "There was a problem with the sampling rate value of output volume")
-        self.assertEqual(protShiftVolCrop.outputVolume.getDim(), (32, 32, 32),
-                         "There was a problem with the dimensions of output volume")
-        self.assertEqual(protShiftVolCrop.shiftX.get(), 5.0, "There was a problem with output shift x")
-        self.assertEqual(protShiftVolCrop.shiftY.get(), 5.0, "There was a problem with output shift y")
-        self.assertEqual(protShiftVolCrop.shiftZ.get(), 5.0, "There was a problem with output shift z")
+        self.assertEqual(protShiftVolCrop.outputVolume.getSamplingRate(), 7.08, (ERROR_SR, "volume"))
+        self.assertEqual(protShiftVolCrop.outputVolume.getDim(), (32, 32, 32), (ERROR_DIM, "volume"))
+        self.assertEqual(protShiftVolCrop.shiftX.get(), 5.0, (ERROR_SHIFT, "x"))
+        self.assertEqual(protShiftVolCrop.shiftY.get(), 5.0, (ERROR_SHIFT, "y"))
+        self.assertEqual(protShiftVolCrop.shiftZ.get(), 5.0, (ERROR_SHIFT, "z"))
 
         protShiftVolPad = self.newProtocol(XmippProtShiftVolume,
                                            inputVol=protImportVol.outputVolume,
@@ -1446,13 +1444,11 @@ class TestXmippShiftParticlesAndVolume(TestXmippBase):
         self.launchProtocol(protShiftVolPad)
         self.assertIsNotNone(protShiftVolPad.getFiles(),
                              "There was a problem with shift pad volume")
-        self.assertEqual(protShiftVolPad.outputVolume.getSamplingRate(), 7.08,
-                         "There was a problem with the sampling rate value of output volume")
-        self.assertEqual(protShiftVolPad.outputVolume.getDim(), (80, 80, 80),
-                         "There was a problem with the dimensions of output volume")
-        self.assertEqual(protShiftVolPad.shiftX.get(), 5.0, "There was a problem with output shift x")
-        self.assertEqual(protShiftVolPad.shiftY.get(), 5.0, "There was a problem with output shift y")
-        self.assertEqual(protShiftVolPad.shiftZ.get(), 5.0, "There was a problem with output shift z")
+        self.assertEqual(protShiftVolCrop.outputVolume.getSamplingRate(), 7.08, (ERROR_SR, "volume"))
+        self.assertEqual(protShiftVolPad.outputVolume.getDim(), (80, 80, 80), (ERROR_DIM, "volume"))
+        self.assertEqual(protShiftVolPad.shiftX.get(), 5.0, (ERROR_SHIFT, "x"))
+        self.assertEqual(protShiftVolPad.shiftY.get(), 5.0, (ERROR_SHIFT, "y"))
+        self.assertEqual(protShiftVolPad.shiftZ.get(), 5.0, (ERROR_SHIFT, "z"))
 
 
 if __name__ == "__main__":

--- a/xmipp3/tests/test_protocols_xmipp_3d.py
+++ b/xmipp3/tests/test_protocols_xmipp_3d.py
@@ -1372,6 +1372,15 @@ class TestXmippShiftParticlesAndVolume(TestXmippBase):
         self.launchProtocol(protShiftParticles)
         self.assertIsNotNone(protShiftParticles.getFiles(),
                              "There was a problem with shift particles")
+        self.assertEqual(protShiftParticles.outputParticles.getSamplingRate(), 7.08,
+                         "There was a problem with the sampling rate value of output particles")
+        self.assertEqual(protShiftParticles.outputParticles.getFirstItem().getDim(), (64, 64, 1),
+                         "There was a problem with the dimensions of output particles")
+        self.assertEqual(protShiftParticles.outputParticles.getSize(), 181,
+                         "There was a problem with the dimensions of output particles")
+        self.assertEqual(protShiftParticles.shiftX.get(), 2.0, "There was a problem with output shift x")
+        self.assertEqual(protShiftParticles.shiftY.get(), 3.0, "There was a problem with output shift y")
+        self.assertEqual(protShiftParticles.shiftZ.get(), 4.0, "There was a problem with output shift z")
 
         protCreateMask = self.newProtocol(XmippProtCreateMask3D,
                                           inputVolume=protImportVol.outputVolume,
@@ -1387,6 +1396,15 @@ class TestXmippShiftParticlesAndVolume(TestXmippBase):
         self.launchProtocol(protShiftParticlesCenterOfMass)
         self.assertIsNotNone(protShiftParticlesCenterOfMass.getFiles(),
                              "There was a problem with shift particles to center of mass")
+        self.assertEqual(protShiftParticlesCenterOfMass.outputParticles.getSamplingRate(), 7.08,
+                         "There was a problem with the sampling rate value of output particles")
+        self.assertEqual(protShiftParticlesCenterOfMass.outputParticles.getFirstItem().getDim(), (64, 64, 1),
+                         "There was a problem with the dimensions of output particles")
+        self.assertEqual(protShiftParticlesCenterOfMass.outputParticles.getSize(), 181,
+                         "There was a problem with the dimensions of output particles")
+        self.assertEqual(protShiftParticlesCenterOfMass.shiftX.get(), 32.0, "There was a problem with output shift x")
+        self.assertEqual(protShiftParticlesCenterOfMass.shiftY.get(), 32.0, "There was a problem with output shift y")
+        self.assertEqual(protShiftParticlesCenterOfMass.shiftZ.get(), 32.0, "There was a problem with output shift z")
 
         protShiftVolPart = self.newProtocol(XmippProtShiftVolume,
                                             inputVol=protImportVol.outputVolume,
@@ -1394,6 +1412,13 @@ class TestXmippShiftParticlesAndVolume(TestXmippBase):
         self.launchProtocol(protShiftVolPart)
         self.assertIsNotNone(protShiftVolPart.getFiles(),
                              "There was a problem with shift volume with particle shifts")
+        self.assertEqual(protShiftVolPart.outputVolume.getSamplingRate(), 7.08,
+                         "There was a problem with the sampling rate value of output volume")
+        self.assertEqual(protShiftVolPart.outputVolume.getDim(), (64, 64, 64),
+                         "There was a problem with the dimensions of output volume")
+        self.assertEqual(protShiftVolPart.shiftX.get(), 2.0, "There was a problem with output shift x")
+        self.assertEqual(protShiftVolPart.shiftY.get(), 3.0, "There was a problem with output shift y")
+        self.assertEqual(protShiftVolPart.shiftZ.get(), 4.0, "There was a problem with output shift z")
 
         protShiftVolCrop = self.newProtocol(XmippProtShiftVolume,
                                             inputVol=protImportVol.outputVolume,
@@ -1404,6 +1429,13 @@ class TestXmippShiftParticlesAndVolume(TestXmippBase):
         self.launchProtocol(protShiftVolCrop)
         self.assertIsNotNone(protShiftVolCrop.getFiles(),
                              "There was a problem with shift crop volume")
+        self.assertEqual(protShiftVolCrop.outputVolume.getSamplingRate(), 7.08,
+                         "There was a problem with the sampling rate value of output volume")
+        self.assertEqual(protShiftVolCrop.outputVolume.getDim(), (32, 32, 32),
+                         "There was a problem with the dimensions of output volume")
+        self.assertEqual(protShiftVolCrop.shiftX.get(), 5.0, "There was a problem with output shift x")
+        self.assertEqual(protShiftVolCrop.shiftY.get(), 5.0, "There was a problem with output shift y")
+        self.assertEqual(protShiftVolCrop.shiftZ.get(), 5.0, "There was a problem with output shift z")
 
         protShiftVolPad = self.newProtocol(XmippProtShiftVolume,
                                            inputVol=protImportVol.outputVolume,
@@ -1414,6 +1446,13 @@ class TestXmippShiftParticlesAndVolume(TestXmippBase):
         self.launchProtocol(protShiftVolPad)
         self.assertIsNotNone(protShiftVolPad.getFiles(),
                              "There was a problem with shift pad volume")
+        self.assertEqual(protShiftVolPad.outputVolume.getSamplingRate(), 7.08,
+                         "There was a problem with the sampling rate value of output volume")
+        self.assertEqual(protShiftVolPad.outputVolume.getDim(), (80, 80, 80),
+                         "There was a problem with the dimensions of output volume")
+        self.assertEqual(protShiftVolPad.shiftX.get(), 5.0, "There was a problem with output shift x")
+        self.assertEqual(protShiftVolPad.shiftY.get(), 5.0, "There was a problem with output shift y")
+        self.assertEqual(protShiftVolPad.shiftZ.get(), 5.0, "There was a problem with output shift z")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
New protocol to shift volumes to a desired coordinate. It can be used to recenter a volume that has been computed from shifted particles.
Tests for shift volume and particles protocols are included.