### PR TITLE
Revert "Co fixes"

### DIFF
--- a/xmipp3/protocols/protocol_preprocess/protocol_process.py
+++ b/xmipp3/protocols/protocol_preprocess/protocol_process.py
@@ -152,7 +152,7 @@ class XmippProcessVolumes(ProtPreprocessVolumes):
             volClass = volInput.getClass()
             vol = volClass() # Create an instance with the same class of input 
             vol.copyInfo(volInput)
-            vol.setLocation(self.outputStk)
+            vol.setLocation(1, self.outputStk)
             if self.outputStk.endswith(".mrc"):
                 self.runJob("xmipp_image_header","-i %s --sampling_rate %f"%(self.outputStk,volInput.getSamplingRate()))
             if volInput.hasOrigin():

--- a/xmipp3/protocols/protocol_preprocess/protocol_process.py
+++ b/xmipp3/protocols/protocol_preprocess/protocol_process.py
@@ -152,7 +152,7 @@ class XmippProcessVolumes(ProtPreprocessVolumes):
             volClass = volInput.getClass()
             vol = volClass() # Create an instance with the same class of input 
             vol.copyInfo(volInput)
-            vol.setLocation(1, self.outputStk)
+            vol.setLocation(self.outputStk)
             if self.outputStk.endswith(".mrc"):
                 self.runJob("xmipp_image_header","-i %s --sampling_rate %f"%(self.outputStk,volInput.getSamplingRate()))
             if volInput.hasOrigin():

--- a/xmipp3/protocols/protocol_validate_overfitting.py
+++ b/xmipp3/protocols/protocol_validate_overfitting.py
@@ -274,7 +274,7 @@ class XmippProtValidateOverfitting(ProtReconstruct3D):
                     os.environ["CUDA_VISIBLE_DEVICES"] = GpuListAux
                 if self.numberOfMpi.get()==1:
                     params += " --device %s" %(GpuListCuda)
-                # params += ' --thr %d' % self.numberOfThreads.get()
+                params += ' --thr %d' % self.numberOfThreads.get()
                 if self.numberOfMpi.get()>1:
                     self.runJob('xmipp_cuda_reconstruct_fourier', params, numberOfMpi=len((self.gpuList.get()).split(','))+1)
                 else:
@@ -326,7 +326,7 @@ class XmippProtValidateOverfitting(ProtReconstruct3D):
                 params += ' --sym %s' % self.symmetryGroup.get()
                 params += ' --max_resolution %0.3f' % self.maxRes
                 params += ' --padding 2'
-                # params += ' --thr 1'
+                params += ' --thr 1'
                 # params += ' --thr %d' % self.numberOfThreads.get()
                 params += ' --sampling %f' % Ts
 
@@ -353,7 +353,7 @@ class XmippProtValidateOverfitting(ProtReconstruct3D):
                         os.environ["CUDA_VISIBLE_DEVICES"] = GpuListAux
                     if self.numberOfMpi.get()==1:
                         params += " --device %s" %(GpuListCuda)
-                    # params += ' --thr %d' % self.numberOfThreads.get()
+                    params += ' --thr %d' % self.numberOfThreads.get()
                     if self.numberOfMpi.get()>1:
                         self.runJob('xmipp_cuda_reconstruct_fourier', params, numberOfMpi=len((self.gpuList.get()).split(','))+1)
                     else:

--- a/xmipp3/protocols/protocol_validate_overfitting.py
+++ b/xmipp3/protocols/protocol_validate_overfitting.py
@@ -326,8 +326,6 @@ class XmippProtValidateOverfitting(ProtReconstruct3D):
                 params += ' --sym %s' % self.symmetryGroup.get()
                 params += ' --max_resolution %0.3f' % self.maxRes
                 params += ' --padding 2'
-                params += ' --thr 1'
-                # params += ' --thr %d' % self.numberOfThreads.get()
                 params += ' --sampling %f' % Ts
 
                 if self.useGpu.get():


### PR DESCRIPTION
Partially reverts I2PC/scipion-em-xmipp#471

Number of threads is used by the protocol and can affect the performance significantly.
See documentation of `cuda_reconstruct_fourier`