### PR TITLE
protocol_analyze_local_ctf: minifix

### DIFF
--- a/xmipp3/protocols/protocol_analyze_local_ctf.py
+++ b/xmipp3/protocols/protocol_analyze_local_ctf.py
@@ -110,7 +110,7 @@ class XmippProtAnalyzeLocalCTF(ProtAnalysis3D):
             mdBlock = emlib.MetaData()
             for xi, yi, deltafi, parti in zip(xbyId,ybyId,meanDefocusbyId,particleIdsbyMicId):
                 objId = mdBlock.addObject()
-                mdBlock.setValue(emlib.MDL_ITEM_ID,long(parti),objId)
+                mdBlock.setValue(emlib.MDL_ITEM_ID,parti,objId)
                 mdBlock.setValue(emlib.MDL_XCOOR,xi,objId)
                 mdBlock.setValue(emlib.MDL_YCOOR,yi,objId)
                 mdBlock.setValue(emlib.MDL_CTF_DEFOCUSA,deltafi,objId)


### PR DESCRIPTION
Minifix detected when checking the protocols that use the new labels added to python_constants 