### PR TITLE
Movie average protocol: fixing crash caused by simultaneous write to the same file 

### DIFF
--- a/xmipp3/protocols/protocol_movie_average.py
+++ b/xmipp3/protocols/protocol_movie_average.py
@@ -151,7 +151,8 @@ class XmippProtMovieAverage(ProtAlignMovies):
 
         self.averageMovie(movie, inputMd, outputMicFn, self.binFactor.get(),
                           roi, self.inputMovies.get().getDark(), gainFn,
-                          splineOrder=self.INTERP_MAP[self.splineOrder.get()])
+                          splineOrder=self.INTERP_MAP[self.splineOrder.get()], 
+                          outxmd="\"\"")
 
         self._storeSummary(movie)
     

--- a/xmipp3/protocols/protocol_movie_average.py
+++ b/xmipp3/protocols/protocol_movie_average.py
@@ -152,7 +152,7 @@ class XmippProtMovieAverage(ProtAlignMovies):
         self.averageMovie(movie, inputMd, outputMicFn, self.binFactor.get(),
                           roi, self.inputMovies.get().getDark(), gainFn,
                           splineOrder=self.INTERP_MAP[self.splineOrder.get()], 
-                          outxmd="\"\"")
+                          outxmd="\"\"") # we're not interested in the metadata
 
         self._storeSummary(movie)
     


### PR DESCRIPTION
removing multiple access to the same output file (the default one) done when several steps are running in parallel