### PR TITLE
Protocol add noise + Viewers Init: fixes

### DIFF
--- a/xmipp3/protocols/protocol_preprocess/protocol_add_noise.py
+++ b/xmipp3/protocols/protocol_preprocess/protocol_add_noise.py
@@ -48,7 +48,8 @@ class XmippProtAddNoise(ProtRefine3D):
     STUDENT_NOISE = 1
     UNIFORM_NOISE = 2
     _lastUpdateVersion = VERSION_1_1
-    #--------------------------- DEFINE param functions ------------------------
+    # --------------------------- DEFINE param functions ------------------------
+
     def _defineParams(self, form):
         
         form.addParam('noiseType', EnumParam,
@@ -95,13 +96,9 @@ class XmippProtAddNoise(ProtRefine3D):
                       condition='noiseType == %d' % self.UNIFORM_NOISE,
                       label="Maximum Value", 
                       help='Please, introduce the maximum value (default = 1).')
-        
-        
         form.addParallelSection(threads=1, mpi=1)
 
-    #--------------------------- INSERT steps functions ------------------------
-
-
+    # --------------------------- INSERT steps functions ------------------------
     def _insertAllSteps(self):        
         self.micsFn = self._getPath()
         # Convert input into xmipp Metadata format
@@ -122,9 +119,8 @@ class XmippProtAddNoise(ProtRefine3D):
             noiseParams = '%f %f' % (self.uniformMin, self.uniformMax)
         return kindNoise, noiseParams
 
-    #--------------------------- INFO functions -------------------------------
+    # --------------------------- INFO functions -------------------------------
     def _validate(self):
-        
         validateMsgs = []
         if self.input and not self.input.hasValue():
             validateMsgs.append('Please provide input volume.')  
@@ -132,19 +128,20 @@ class XmippProtAddNoise(ProtRefine3D):
 
     def _summary(self):
         summary = []
-
-        if  (not hasattr(self,'outputVolume')):
-            summary.append("Output volume not ready yet.")
-        else:
-            summary.append("Volume with %s noise has been obtained" 
-                           % (self.getEnumText("noiseType")) )
-            #
+        if hasattr(self, 'outputVolume'):
+            summary.append("Volume with %s noise has been obtained" % (self.getEnumText("noiseType")))
+        elif hasattr(self, 'outputParticles'):
+            summary.append("Particles with %s noise has been obtained" % (self.getEnumText("noiseType")))
+        elif not hasattr(self, 'outputVolume') or not hasattr(self, 'outputParticles'):
+                summary.append("Output not ready yet.")
         return summary
     
     def _methods(self):
         messages = []
-        if (hasattr(self,'outputVolume')):
+        if hasattr(self, 'outputVolume'):
             messages.append('Noisy volume has been obtained')
+        elif hasattr(self, 'outputParticles'):
+            messages.append('Noisy particles have been obtained')
         return messages
     
     def _citations(self):
@@ -164,7 +161,7 @@ class XmippProtAddNoiseVolumes(XmippProtAddNoise):
     """
     _label = 'add noise volume/s'
     
-    #--------------------------- DEFINE param functions ------------------------
+    # --------------------------- DEFINE param functions ------------------------
     def _defineParams(self, form):
         form.addSection(label='Input')
        
@@ -232,6 +229,7 @@ class XmippProtAddNoiseVolumes(XmippProtAddNoise):
     def _isSingleVolume(self):
         return isinstance(self.input.get(), Volume)
 
+
 class XmippProtAddNoiseParticles(XmippProtAddNoise):
     """    
     Given a set of particles, the protocol will add noise to them 
@@ -239,7 +237,7 @@ class XmippProtAddNoiseParticles(XmippProtAddNoise):
     """
     _label = 'add noise particles'
     
-    #--------------------------- DEFINE param functions --------------------
+    # --------------------------- DEFINE param functions --------------------
     def _defineParams(self, form):
         form.addSection(label='Input')
        

--- a/xmipp3/viewers/__init__.py
+++ b/xmipp3/viewers/__init__.py
@@ -66,4 +66,4 @@ from .viewer_deep_align import XmippDeepAlignViewer
 
 # TODO: Import from continuousflex the modules needed to create clusters (soft dependency)
 from .viewer_angular_alignment_sph import XmippAngularAlignmentSphViewer
-
+from .viewer_analyze_local_ctf import XmippAnalyzeLocalCTFViewer


### PR DESCRIPTION
Ramdom fixes to bugs that I have recently found:
- Fix summary and methods of `protocol add noise` (both `protocol add noise to volume` and `protocol add noise to particle` inherit them and they were working fine just for volumes but not for particles) + some formatting
- Add analyze local defocus protocol viewer to init viewer (I am using again this protocol that I think was unused since I created and merged it almost 3 years ago and the viewer was not displayed because it was not in the init)