### PR TITLE
JMK - convert pdb - remove size if deactivated

### DIFF
--- a/xmipp3/protocols/protocol_convert_pdb.py
+++ b/xmipp3/protocols/protocol_convert_pdb.py
@@ -134,10 +134,10 @@ class XmippProtConvertPdb(ProtInitialVolume):
         if self.setSize:
             args += ' --size'
 
-        if self.size_x.hasValue():
+        if self.size_x.hasValue() and self.setSize:
             args += ' %d' % self.size_x.get()
 
-        if self.size_y.hasValue() and self.size_z.hasValue():
+        if self.size_y.hasValue() and self.size_z.hasValue() and self.setSize:
             args += ' %d %d' % (self.size_y.get(), self.size_z.get())
 
         self.info("Input file: " + pdbFn)


### PR DESCRIPTION
Without this fix, this protocol throws an error if someone sets a size and then decides not to use it e.g.
```
00018:    xmipp_volume_from_pdb -i Runs/000002_ProtImportPdb/extra/7ke9.pdb --sampling 1.000000 -o Runs/000640_XmippProtConvertPdb/extra/7ke9 195 195 195
00019:   Protocol failed: Command ' xmipp_volume_from_pdb -i Runs/000002_ProtImportPdb/extra/7ke9.pdb --sampling 1.000000 -o Runs/000640_XmippProtConvertPdb/extra/7ke9 195 195 195' returned non-zero exit status 1.
```

With the fix, these are only added if setSize is still true and the protocol works again
