### PR TITLE
Center particles: protocol simplified

### DIFF
--- a/xmipp3/protocols/protocol_center_particles.py
+++ b/xmipp3/protocols/protocol_center_particles.py
@@ -143,15 +143,55 @@ class XmippProtCenterParticles(ProtClassify2D):
 
     def createOutputStep(self):
         inputParticles = self.inputClasses.get().getImages()
+
+        outputClasses = self._createSetOfClasses2D(inputParticles)
+        self._fillClasses(outputClasses)
+        result = {'outputClasses': outputClasses}
+        self._defineOutputs(**result)
+        self._defineSourceRelation(self.inputClasses, outputClasses)
+
         outputParticles = self._createSetOfParticles()
         outputParticles.copyInfo(inputParticles)
-
         self._fillParticles(outputParticles)
         result = {'outputParticles': outputParticles}
         self._defineOutputs(**result)
         self._defineSourceRelation(self.inputClasses, outputParticles)
 
     # --------------------------- UTILS functions ------------------------------
+    def _fillClasses(self, outputClasses):
+        """ Create the SetOfClasses2D """
+        inputSet = self.inputClasses.get().getImages()
+        myRep = md.MetaData('classes@' + self._getExtraPath(
+            'final_classes.xmd'))
+
+        for row in md.iterRows(myRep):
+            fn = row.getValue(md.MDL_IMAGE)
+            rep = Particle()
+            rep.setLocation(xmippToLocation(fn))
+            repId = row.getObjId()
+            newClass = Class2D(objId=repId)
+            newClass.setAlignment2D()
+            newClass.copyInfo(inputSet)
+            newClass.setAcquisition(inputSet.getAcquisition())
+            newClass.setRepresentative(rep)
+            outputClasses.append(newClass)
+
+        i = 1
+        mdBlocks = md.getBlocksInMetaDataFile(self._getExtraPath(
+            'final_classes.xmd'))
+        for block in mdBlocks:
+            if block.startswith('class00'):
+                mdClass = md.MetaData(block + "@" + self._getExtraPath(
+                    'final_classes.xmd'))
+                imgClassId = i
+                newClass = outputClasses[imgClassId]
+                newClass.enableAppend()
+                for row in md.iterRows(mdClass):
+                    part = rowToParticle(row)
+                    newClass.append(part)
+                i += 1
+                newClass.setAlignment2D()
+                outputClasses.update(newClass)
 
     def _fillParticles(self, outputParticles):
         """ Create the SetOfParticles and SetOfCoordinates"""

--- a/xmipp3/protocols/protocol_center_particles.py
+++ b/xmipp3/protocols/protocol_center_particles.py
@@ -119,10 +119,6 @@ class XmippProtCenterParticles(ProtClassify2D):
                     resultMat.setMatrix(resultMatrix)
                     rowOut=md.Row()
                     rowOut.copyFromRow(rowIn)
-                    print('rowOut.getValue(md.MDL_XCOOR): {}'.format(rowOut.getValue(
-                        md.MDL_XCOOR)))#None
-                    print('rowIn.getValue(md.MDL_XCOOR): {}'.format(rowIn.getValue(
-                        md.MDL_XCOOR)))#None
                     alignmentToRow(resultMat, rowOut, ALIGN_2D)
                     if flag_psi==False:
                         newAngle = rowOut.getValue(md.MDL_ANGLE_PSI)
@@ -133,10 +129,6 @@ class XmippProtCenterParticles(ProtClassify2D):
                     inPoint = np.array([[0.],[0.],[0.],[1.]])
                     invResultMat = np.linalg.inv(resultMatrix)
                     centerPoint = np.dot(invResultMat,inPoint)
-                    print('centerPoint: {}'.format(centerPoint))#[[-0.22759346]    [-2.22834146]    [ 0.][1.]
-                    print('md.MDL_XCOOR: {}'.format(md.MDL_XCOOR))#37
-                    print('rowOut.getValue(md.MDL_XCOOR): {}'.format(rowOut.getValue(
-                        md.MDL_XCOOR)))#None
 
                     rowOut.setValue(md.MDL_XCOOR, rowOut.getValue(
                         md.MDL_XCOOR)+int(centerPoint[0]))
@@ -217,4 +209,13 @@ class XmippProtCenterParticles(ProtClassify2D):
         summary.append("Realignment of %s classes."
                        % self.inputClasses.get().getSize())
         return summary
+
+    def _validate(self):
+        errors = []
+        try:
+            self.inputClasses.get().getImages().getAcquisition()
+        except AttributeError:
+            errors.append('InputClasses has not clases')
+
+        return errors
 

--- a/xmipp3/protocols/protocol_center_particles.py
+++ b/xmipp3/protocols/protocol_center_particles.py
@@ -1,6 +1,7 @@
 # ******************************************************************************
 # *
 # * Authors:     Amaya Jimenez Moreno (ajimenez@cnb.csic.es)
+# *              Alberto García Mena (alberto.garcia@cnb.csic.es)
 # *
 # * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
 # *

--- a/xmipp3/protocols/protocol_center_particles.py
+++ b/xmipp3/protocols/protocol_center_particles.py
@@ -52,7 +52,6 @@ class XmippProtCenterParticles(ProtClassify2D):
                       label="Input Classes",
                       help='Set of classes to be realing')
         form.addParallelSection(threads=0, mpi=0)
-
     # --------------------------- INSERT steps functions -----------------------
     def _insertAllSteps(self):
         self._insertFunctionStep('realignStep')
@@ -120,6 +119,10 @@ class XmippProtCenterParticles(ProtClassify2D):
                     resultMat.setMatrix(resultMatrix)
                     rowOut=md.Row()
                     rowOut.copyFromRow(rowIn)
+                    print('rowOut.getValue(md.MDL_XCOOR): {}'.format(rowOut.getValue(
+                        md.MDL_XCOOR)))#None
+                    print('rowIn.getValue(md.MDL_XCOOR): {}'.format(rowIn.getValue(
+                        md.MDL_XCOOR)))#None
                     alignmentToRow(resultMat, rowOut, ALIGN_2D)
                     if flag_psi==False:
                         newAngle = rowOut.getValue(md.MDL_ANGLE_PSI)
@@ -130,6 +133,11 @@ class XmippProtCenterParticles(ProtClassify2D):
                     inPoint = np.array([[0.],[0.],[0.],[1.]])
                     invResultMat = np.linalg.inv(resultMatrix)
                     centerPoint = np.dot(invResultMat,inPoint)
+                    print('centerPoint: {}'.format(centerPoint))#[[-0.22759346]    [-2.22834146]    [ 0.][1.]
+                    print('md.MDL_XCOOR: {}'.format(md.MDL_XCOOR))#37
+                    print('rowOut.getValue(md.MDL_XCOOR): {}'.format(rowOut.getValue(
+                        md.MDL_XCOOR)))#None
+
                     rowOut.setValue(md.MDL_XCOOR, rowOut.getValue(
                         md.MDL_XCOOR)+int(centerPoint[0]))
                     rowOut.setValue(md.MDL_YCOOR, rowOut.getValue(

--- a/xmipp3/protocols/protocol_center_particles.py
+++ b/xmipp3/protocols/protocol_center_particles.py
@@ -51,6 +51,13 @@ class XmippProtCenterParticles(ProtClassify2D):
                       important=True,
                       label="Input Classes",
                       help='Set of classes to be realing')
+        form.addParam('inputMics', params.PointerParam,
+                      pointerClass='SetOfMicrographs',
+                      important=True,
+                      label="Set of micrographs",
+                      help='Set of micrographs related to the selected input '
+                           'classes')
+
         form.addParallelSection(threads=0, mpi=0)
     # --------------------------- INSERT steps functions -----------------------
     def _insertAllSteps(self):


### PR DESCRIPTION
Before the protocol to center particles had as output the centered classes, the centered particle and the coordinates.

With this PR the protocol is simplified and only centers the particle returning the classes and the particles, if the set of coordinates is needed,  you have to manually add the protocol to extract coordinates.