### PR TITLE
protocol_shift_particles: apply transform is now optional

### DIFF
--- a/xmipp3/protocols/protocol_shift_particles.py
+++ b/xmipp3/protocols/protocol_shift_particles.py
@@ -61,6 +61,11 @@ class XmippProtShiftParticles(EMProtocol):
         form.addParam('inputMask', PointerParam, pointerClass='VolumeMask', label="Volume mask", allowsNull=True,
                       condition='not option', help='3D mask to compute the center of mass, the particles will be '
                                                    'shifted to the computed center of mass')
+        form.addParam('applyShift', BooleanParam, label='Apply shift to particles?', default='True',
+                      help='Yes: the output particles have shift applied. No: output particles have the computed shift '
+                           'in the transform matrix of the metadata, but it is not applied (i.e. the output images are '
+                           'the same of input images). This option takes less time and the shift could be applied later'
+                           ' using protocol "xmipp3 - apply alignment 2d" or by re-extracting the particles.')
         form.addParam('boxSizeBool', BooleanParam, label='Use original box size for the shifted particles?',
                       default='True', help='Use input particles box size for the shifted particles.')
         form.addParam('boxSize', IntParam, label='Final box size', condition='not boxSizeBool',
@@ -109,7 +114,9 @@ class XmippProtShiftParticles(EMProtocol):
             interp = 'linear'
         else:
             interp = 'spline'
-        args += ' --apply_transform --dont_wrap --interp %s' % interp
+        if self.applyShift.get():
+            args += ' --apply_transform'
+        args += ' --dont_wrap --interp %s' % interp
         if self.inv.get():
             args += ' --inverse'
         self.runJob(program, args)

--- a/xmipp3/protocols/protocol_shift_particles.py
+++ b/xmipp3/protocols/protocol_shift_particles.py
@@ -62,10 +62,11 @@ class XmippProtShiftParticles(EMProtocol):
                       condition='not option', help='3D mask to compute the center of mass, the particles will be '
                                                    'shifted to the computed center of mass')
         form.addParam('applyShift', BooleanParam, label='Apply shift to particles?', default='True',
-                      help='Yes: the output particles have shift applied. No: output particles have the computed shift '
-                           'in the transform matrix of the metadata, but it is not applied (i.e. the output images are '
-                           'the same of input images). This option takes less time and the shift could be applied later'
-                           ' using protocol "xmipp3 - apply alignment 2d" or by re-extracting the particles.')
+                      help='Yes: The shift is applied to particle images and zero shift is stored in the metadata. No: '
+                           'The shift is stored in the transformation matrix in the metadata, but not applied to the '
+                           'particle image (i.e. the output images are the same of input images). This option takes '
+                           'less time and the shift could be applied later using protocol "xmipp3 - apply alignment 2d"'
+                           ' or by re-extracting the particles.')
         form.addParam('boxSizeBool', BooleanParam, label='Use original box size for the shifted particles?',
                       default='True', help='Use input particles box size for the shifted particles.')
         form.addParam('boxSize', IntParam, label='Final box size', condition='not boxSizeBool',


### PR DESCRIPTION
The computed shift was always applied to output particles, however, by users demand, now it is optional. Thus the program now can compute the shift and apply it or just store the computed shift in the metadata of the particle (transform matrix, x and y coordinates) but it does not apply it, which saves time. The stored shift could be applied afterwards using protocol "apply_alignment_2d" or re-extracting the particles with the shifted coordinates.