### PR TITLE
DenoiseParticles: fixing inputClasses bug 

### DIFF
--- a/xmipp3/protocols/protocol_denoise_particles.py
+++ b/xmipp3/protocols/protocol_denoise_particles.py
@@ -92,7 +92,7 @@ class XmippProtDenoiseParticles(ProtProcessParticles):
         if isinstance(self.inputClasses.get(), SetOfVolumes):
             writeSetOfClasses2D(self.inputClasses.get(), classesMd)
         else:
-            writeSetOfParticles(self.inputClasses.get(), classesMd)
+            writeSetOfParticles(self.inputParticles.get(), classesMd)
 
         fnRoot = self._getExtraPath('pca')
         fnRootDenoised = self._getExtraPath('imagesDenoised')


### PR DESCRIPTION
With this PR the test _scipion3 tests xmipp3.tests.test_protocols_xmipp_2d.TestXmippDenoiseParticles_ is fixed.
Review that the change makes sense