### PR TITLE
Protocol Denoise particle

### DIFF
--- a/xmipp3/protocols/protocol_denoise_particles.py
+++ b/xmipp3/protocols/protocol_denoise_particles.py
@@ -29,6 +29,7 @@ from pyworkflow.object import String
 from pyworkflow.protocol.params import IntParam, PointerParam, LEVEL_ADVANCED
 from pwem.protocols import ProtProcessParticles
 from pwem.objects import SetOfVolumes
+from pwem.objects import SetOfAverages
 
 from xmipp3.convert import (writeSetOfParticles, writeSetOfClasses2D,
                             xmippToLocation)
@@ -89,14 +90,10 @@ class XmippProtDenoiseParticles(ProtProcessParticles):
         imagesMd = self._getPath('images.xmd')
         writeSetOfParticles(self.inputParticles.get(), imagesMd)
         classesMd = self._getPath('classes.xmd')
-        if isinstance(self.inputClasses.get(), SetOfVolumes):
+        if isinstance(self.inputClasses.get(), SetOfAverages):
             writeSetOfClasses2D(self.inputClasses.get(), classesMd)
         else:
-            writeSetOfParticles(self.inputClasses.get(), classesMd)
-        if isinstance(self.inputClasses.get(), SetOfVolumes):
             writeSetOfClasses2D(self.inputClasses.get(), classesMd)
-        else:
-            writeSetOfParticles(self.inputParticles.get(), classesMd)
 
         fnRoot = self._getExtraPath('pca')
         fnRootDenoised = self._getExtraPath('imagesDenoised')


### PR DESCRIPTION
The test failed because there was an error importing _setofAverages_ and writing it.
With this fix, the test pass, but I don't know how to test if works with _setofAverages_ and not a _setofClasses_

Test:
[scipion3 tests xmipp3.tests.test_protocols_xmipp_2d.TestXmippDenoiseParticles](http://scipion-test.cnb.csic.es:9980/#/builders/19/builds/183/steps/54/logs/stdio
)
