### PR TITLE
change output from stk  (spider) to mrcs (mrc)

### DIFF
--- a/xmipp3/protocols/protocol_preprocess/protocol_process.py
+++ b/xmipp3/protocols/protocol_preprocess/protocol_process.py
@@ -105,7 +105,7 @@ class XmippProcessParticles(ProtProcessParticles):
     def _defineFilenames(self):
         self.inputFn = self._getTmpPath('input_particles.xmd')
         self.outputMd = self._getExtraPath('output_images.xmd')
-        self.outputStk = self._getExtraPath('output_images.stk')
+        self.outputStk = self._getExtraPath('output_images.mrcs')
 
 
 class XmippProcessVolumes(ProtPreprocessVolumes):


### PR DESCRIPTION
Save images by default in mrc format instead of spider. This saves time since there are several programs that can only deal with mrc.