### PR TITLE
fix scipy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 scikit-learn==0.22.1
+scipy<=1.8.1
 joblib
 peppercorn
 plotter


### PR DESCRIPTION
Fix scipy to avoid dependency problem:
PyWavelets --> scipy>=0.17.0 --> scipy 1.9 (available since 2 days ago) --> numpy >= 1.19 (incompatible with pyworkflow <=1.18.4

This is causing installation to fail at http://scipion-test.cnb.csic.es:9980/#/builders/39/builds/303/steps/3/logs/stdio