### PR TITLE
protocol_postProcessing_deepPostProcessing: TF_FORCE_GPU_ALLOW_GROWTH

### DIFF
--- a/xmipp3/protocols/protocol_postProcessing_deepPostProcessing.py
+++ b/xmipp3/protocols/protocol_postProcessing_deepPostProcessing.py
@@ -244,6 +244,7 @@ class XmippProtDeepVolPostProc(ProtAnalysis3D, xmipp3.XmippProtocol):
         else: #self.NORMALIZATION_MASK
           params+= " --checkpoint  %s "%self.getModel("deepEMhancer", "production_checkpoints/deepEMhancer_masked.hd5")
 
+        os.environ['TF_FORCE_GPU_ALLOW_GROWTH'] = 'true'
         self.runJob("xmipp_deep_volume_postprocessing", params, numberOfMpi=1)
 
                                                         


### PR DESCRIPTION
Allowing not allocate all the memory in the GPU, avoiding crashes.
The test pass.