### PR TITLE
Protocol center particles and Gl2d (all options): fix streaming

### DIFF
--- a/xmipp3/protocols/protocol_center_particles.py
+++ b/xmipp3/protocols/protocol_center_particles.py
@@ -120,7 +120,6 @@ class XmippProtCenterParticles(ProtClassify2D):
                 mdClass = md.MetaData(block + "@" + inputMdName)
                 mdNewClass = md.MetaData()
                 i += 1
-                j = 0
                 for rowIn in md.iterRows(mdClass):
                     #To create the transformation matrix (and its parameters)
                     #  for the realigned particles
@@ -156,7 +155,6 @@ class XmippProtCenterParticles(ProtClassify2D):
                         md.MDL_YCOOR)+int(centerPoint[1]))
 
                     rowOut.addToMd(mdNewClass)
-                    j += 1
 
                 mdNewClass.write(block + "@" + self._getExtraPath(
                     'final_classes.xmd'), MD_APPEND)
@@ -252,10 +250,10 @@ class XmippProtCenterParticles(ProtClassify2D):
 
     def _validate(self):
         errors = []
-        # try:
-        #     self.inputClasses.get().getImages()
-        # except AttributeError:
-        #     errors.append('Try and catch InputClasses has no particles.')
+        try:
+            self.inputClasses.get().getImages()
+        except AttributeError:
+            errors.append('Try and catch InputClasses has no particles.')
 
         return errors
 

--- a/xmipp3/protocols/protocol_center_particles.py
+++ b/xmipp3/protocols/protocol_center_particles.py
@@ -51,7 +51,7 @@ class XmippProtCenterParticles(ProtClassify2D):
                       pointerClass='SetOfClasses2D',
                       important=True,
                       label="Input Classes",
-                      help='Set of classes to be realing')
+                      help='Set of classes to be read')
         form.addParam('inputMics', params.PointerParam,
                       pointerClass='SetOfMicrographs',
                       important=True,
@@ -175,7 +175,7 @@ class XmippProtCenterParticles(ProtClassify2D):
 
     def createOutputStep(self):
         inputParticles = self.inputClasses.get().getImages()
-        outputClasses = self._createSetOfClasses2D(inputParticles)
+        outputClasses = self._createSetOfClasses2D(self.inputClasses.get().getImagesPointer())
         self._fillClasses(outputClasses)
         result = {'outputClasses': outputClasses}
         self._defineOutputs(**result)
@@ -252,10 +252,10 @@ class XmippProtCenterParticles(ProtClassify2D):
 
     def _validate(self):
         errors = []
-        try:
-            self.inputClasses.get().getImages().getAcquisition()
-        except AttributeError:
-            errors.append('InputClasses has not clases')
+        # try:
+        #     self.inputClasses.get().getImages()
+        # except AttributeError:
+        #     errors.append('Try and catch InputClasses has no particles.')
 
         return errors
 

--- a/xmipp3/protocols/protocol_center_particles.py
+++ b/xmipp3/protocols/protocol_center_particles.py
@@ -120,6 +120,7 @@ class XmippProtCenterParticles(ProtClassify2D):
                 mdClass = md.MetaData(block + "@" + inputMdName)
                 mdNewClass = md.MetaData()
                 i += 1
+                flag_psi = True
                 for rowIn in md.iterRows(mdClass):
                     #To create the transformation matrix (and its parameters)
                     #  for the realigned particles

--- a/xmipp3/protocols/protocol_classification_gpuCorr.py
+++ b/xmipp3/protocols/protocol_classification_gpuCorr.py
@@ -201,9 +201,7 @@ class XmippProtGpuCrrCL2D(ProtAlign2D):
 
 
     def createOutputStep(self):
-
-        inputParticles = self.inputParticles.get()
-        classes2DSet = self._createSetOfClasses2D(inputParticles)
+        classes2DSet = self._createSetOfClasses2D(self.inputParticles)
         self._fillClassesFromLevel(classes2DSet)
         result = {'outputClasses': classes2DSet}
         self._defineOutputs(**result)

--- a/xmipp3/protocols/protocol_classification_gpuCorr_full.py
+++ b/xmipp3/protocols/protocol_classification_gpuCorr_full.py
@@ -753,10 +753,8 @@ class XmippProtStrGpuCrrCL2D(ProtAlign2D):
 
 
     def _createFinalClasses(self):
-
-        inputs = self.inputParticles.get()
         # Here the defineOutputs function will call the write() method
-        outputSet = self._createSetOfClasses2D(inputs)
+        outputSet = self._createSetOfClasses2D(self.inputParticles)
         self._fillClasses(outputSet)
         self._defineOutputs(**{'outputClasses': outputSet})
         self._defineSourceRelation(self.inputParticles, outputSet)

--- a/xmipp3/protocols/protocol_classification_gpuCorr_semi.py
+++ b/xmipp3/protocols/protocol_classification_gpuCorr_semi.py
@@ -340,13 +340,11 @@ class XmippProtStrGpuCrrSimple(ProtAlign2D):
         firstTime = True
 
         if outputClasses is None:
-            # outputClasses=self._createSetOfClasses2D(self.inputParticles.get())
             outputClasses = self._createSetOfClasses2D(self.inputParticles)
         else:
             firstTime = False
             outputClasses = SetOfClasses2D(filename=outputClasses.getFileName())
             outputClasses.setStreamState(streamMode)
-            # outputClasses.setImages(self.inputParticles.get())
             outputClasses.setImages(self.inputParticles)
 
         self._fillClassesFromMd(outFnDone, outputClasses, firstTime, streamMode)

--- a/xmipp3/protocols/protocol_classification_gpuCorr_semi.py
+++ b/xmipp3/protocols/protocol_classification_gpuCorr_semi.py
@@ -340,12 +340,14 @@ class XmippProtStrGpuCrrSimple(ProtAlign2D):
         firstTime = True
 
         if outputClasses is None:
-            outputClasses=self._createSetOfClasses2D(self.inputParticles.get())
+            # outputClasses=self._createSetOfClasses2D(self.inputParticles.get())
+            outputClasses = self._createSetOfClasses2D(self.inputParticles)
         else:
             firstTime = False
             outputClasses = SetOfClasses2D(filename=outputClasses.getFileName())
             outputClasses.setStreamState(streamMode)
-            outputClasses.setImages(self.inputParticles.get())
+            # outputClasses.setImages(self.inputParticles.get())
+            outputClasses.setImages(self.inputParticles)
 
         self._fillClassesFromMd(outFnDone, outputClasses, firstTime, streamMode)
         self._updateOutputSet(outputName, outputClasses, streamMode)


### PR DESCRIPTION
Change direct pointers to indirect pointers in the output. This is done to avoid problems when running in streaming.