### PR TITLE
subtract_projection: more small fixes

### DIFF
--- a/xmipp3/protocols/protocol_subtract_projection.py
+++ b/xmipp3/protocols/protocol_subtract_projection.py
@@ -42,7 +42,7 @@ class XmippProtSubtractProjectionBase(EMProtocol):
     @classmethod
     def _defineParams(cls, form):
         form.addSection(label='Input')
-        form.addParam('inputParticles', PointerParam, pointerClass='SetOfParticles', label="Particles: ",
+        form.addParam('inputParticles', PointerParam, pointerClass='SetOfParticles', label="Particles ",
                       help='Specify a SetOfParticles')
         form.addParam('vol', PointerParam, pointerClass='Volume', label="Reference volume ",
                       help='Specify a volume.')
@@ -93,11 +93,12 @@ class XmippProtSubtractProjection(XmippProtSubtractProjectionBase):
     # --------------------------- DEFINE param functions --------------------------------------------
     def _defineParams(self, form):
         XmippProtSubtractProjectionBase._defineParams(form)
-        form.addParam('mask', PointerParam, pointerClass='VolumeMask', label='Mask for region to keep', allowsNull=True,
-                      help='Specify a 3D mask for the region of the input volume that you want to keep. '
-                           'If no mask is given, the subtraction is performed in whole images.')
-        form.addParam('subtract', EnumParam, default=0, choices=["No", "Yes"],
-                      label="The mask contains the part to SUBTRACT?")
+        form.addParam('mask', PointerParam, pointerClass='VolumeMask', label='Mask ', allowsNull=True,
+                      help='Specify a 3D mask for the region of the input volume that you want to keep or subtract, '
+                           'avoiding masks with 1s in background. If no mask is given, the subtraction is performed in'
+                           ' whole images.')
+        form.addParam('subtract', EnumParam, default=0, choices=["Keep", "Subtract"], display=EnumParam.DISPLAY_HLIST,
+                      label="Mask contains the part to ")
     # --------------------------- INSERT steps functions --------------------------------------------
     def _insertSubSteps(self):
         self._insertFunctionStep('convertStep')
@@ -122,6 +123,8 @@ class XmippProtSubtractProjection(XmippProtSubtractProjectionBase):
             args += ' --mask %s' % mask.getFileName()
         if self.nonNegative.get():
             args += ' --nonNegative'
+        if self.subtract.get():
+            args += ' --subtract'
         self.runJob("xmipp_subtract_projection", args)
 
     # --------------------------- INFO functions --------------------------------------------

--- a/xmipp3/protocols/protocol_subtract_projection.py
+++ b/xmipp3/protocols/protocol_subtract_projection.py
@@ -27,7 +27,7 @@
 # **************************************************************************
 
 from os.path import basename
-from pyworkflow.protocol.params import PointerParam, BooleanParam, IntParam, FloatParam
+from pyworkflow.protocol.params import PointerParam, BooleanParam, IntParam, FloatParam, EnumParam
 from pyworkflow.protocol.constants import LEVEL_ADVANCED
 from pwem import emlib
 from pwem.protocols import EMProtocol
@@ -96,9 +96,8 @@ class XmippProtSubtractProjection(XmippProtSubtractProjectionBase):
         form.addParam('mask', PointerParam, pointerClass='VolumeMask', label='Mask for region to keep', allowsNull=True,
                       help='Specify a 3D mask for the region of the input volume that you want to keep. '
                            'If no mask is given, the subtraction is performed in whole images.')
-        form.addParam('mwidth', FloatParam, label="Extra width in final mask: ", default=-1, expertLevel=LEVEL_ADVANCED,
-                      help='Length (in A) to add for each side to the final mask. -1 means no mask.')
-
+        form.addParam('subtract', EnumParam, default=0, choices=["No", "Yes"],
+                      label="The mask contains the part to SUBTRACT?")
     # --------------------------- INSERT steps functions --------------------------------------------
     def _insertSubSteps(self):
         self._insertFunctionStep('convertStep')
@@ -113,10 +112,10 @@ class XmippProtSubtractProjection(XmippProtSubtractProjectionBase):
         fnVol = vol.getFileName()
         if fnVol.endswith('.mrc'):
             fnVol += ':mrc'
-        args = '-i %s --ref %s -o %s --sampling %f --max_resolution %f --fmask_width %f --padding %f ' \
+        args = '-i %s --ref %s -o %s --sampling %f --max_resolution %f --padding %f ' \
                '--sigma %d --limit_freq %d --cirmaskrad %d --save %s' % \
                (self._getExtraPath(self.INPUT_PARTICLES), fnVol, self._getExtraPath("output_particles"),
-                vol.getSamplingRate(), self.resol.get(), self.mwidth.get(), self.pad.get(), self.sigma.get(),
+                vol.getSamplingRate(), self.resol.get(), self.pad.get(), self.sigma.get(),
                 int(self.limit_freq.get()), self.cirmaskrad.get(), self._getExtraPath())
         mask = self.mask.get()
         if mask is not None:


### PR DESCRIPTION
- now the input mask can have 1s in the part to keep or subtract, thus a new flag has been set for it => adjust form and params in command 
- remove unnecessary final mask => remove param in command
This PR goes together with https://github.com/I2PC/xmipp/pull/676