### PR TITLE
Xmipp_day: protocol_align_volume_and_particles: add alingment validation

### DIFF
--- a/xmipp3/protocols/protocol_align_volume_and_particles.py
+++ b/xmipp3/protocols/protocol_align_volume_and_particles.py
@@ -231,6 +231,8 @@ class XmippProtAlignVolumeParticles(ProtAlignVolume):
     
     def _validate(self):
         errors = []
+        if self.inputParticles.get().hasAlignment() is False:
+            errors.append("Input particles need to be aligned (they should have transformation matrix)")
         return errors
     
     def _summary(self):


### PR DESCRIPTION
To avoid protocol fail because input particles do not have transform matrix