### PR TITLE
comment out deprecated viewer_mltomo

### DIFF
--- a/xmipp3/viewers/__init__.py
+++ b/xmipp3/viewers/__init__.py
@@ -32,7 +32,7 @@ from .viewer_ctf_consensus import XmippCTFConsensusViewer
 from .viewer_deep_consensus import XmippDeepConsensusViewer
 from .viewer_deep_micrograph_cleaner import XmippDeepMicrographViewer
 from .viewer_ml2d import XmippML2DViewer
-from .viewer_mltomo import XmippMLTomoViewer
+#from .viewer_mltomo import XmippMLTomoViewer
 from .viewer_movie_alignment import XmippMovieAlignViewer, XmippMovieMaxShiftViewer
 from .viewer_normalize_strain import XmippNormalizeStrainViewer
 from .viewer_resolution3d import XmippResolution3DViewer


### PR DESCRIPTION
This is needed downstream of #599 

Otherwise, all viewers don't work with the following error:
```
 > error when importing from xmipp3.viewers: No module named 'xmipp3.viewers.viewer_mltomo'
   File "/mnt/c/Users/james/code/xmipp-bundle/src/scipion-em-xmipp/xmipp3/viewers/__init__.py", line 35, in <module>
   Check the plugin manager (Configuration->Plugins in Scipion manager window) 
   or use 'scipion installp --help --checkUpdates' in the command line to check for upgrades,
   it could be a versions compatibility issue.
```

