### PR TITLE
subtract_projection & volume_consensus: validate same sampling rate with tolerance in third decimal

### DIFF
--- a/xmipp3/protocols/protocol_subtract_projection.py
+++ b/xmipp3/protocols/protocol_subtract_projection.py
@@ -135,10 +135,10 @@ class XmippProtSubtractProjection(XmippProtSubtractProjectionBase):
         mask = self.mask.get()
         if part.getDim()[0] != vol.getDim()[0]:
             errors.append("Input particles and volume should have same X and Y dimensions")
-        if part.getSamplingRate() != vol.getSamplingRate():
+        if round(part.getSamplingRate(), 2) != round(vol.getSamplingRate(), 2):
             errors.append("Input particles and volume should have same sampling rate")
         if mask:
-            if vol.getSamplingRate() != mask.getSamplingRate():
+            if round(vol.getSamplingRate(), 2) != round(mask.getSamplingRate(), 2):
                 errors.append("Input volume and mask should have same sampling rate")
             if vol.getDim() != mask.getDim():
                 errors.append("Input volume and mask should have same dimensions")
@@ -205,7 +205,7 @@ class XmippProtBoostParticles(XmippProtSubtractProjectionBase):
         vol = self.vol.get()
         if part.getDim()[0] != vol.getDim()[0]:
             errors.append("Input particles and volume should have same X and Y dimensions")
-        if part.getSamplingRate() != vol.getSamplingRate():
+        if round(part.getSamplingRate(), 2) != round(vol.getSamplingRate(), 2):
             errors.append("Input particles and volume should have same sampling rate")
         if self.resol.get() == 0:
             errors.append("Resolution (angstroms) should be bigger than 0")

--- a/xmipp3/protocols/protocol_volume_consensus.py
+++ b/xmipp3/protocols/protocol_volume_consensus.py
@@ -112,7 +112,7 @@ class XmippProtVolConsensus(ProtInitialVolume):
         errors = []
         voxel_size = []
         for i, vol in enumerate(self.vols):
-            voxel_size.append(vol.get().getSamplingRate())
+            voxel_size.append(round(vol.get().getSamplingRate(), 2))
         result = all(element == voxel_size[0] for element in voxel_size)
         if not result:
             errors.append('Pixel size should be the same for all input volumes.')


### PR DESCRIPTION
Validation checks if inputs have same sampling rate, in Scipion sampling rate is showed with just two decimals, but in some cases sampling rate is stored underneath with 3 or more decimals that are not showed in the GUI. If this is the case, the validate in these protocols didn't allow to execute them as the sampling rate was not exactly equal, however we consider in general that a sampling rate with the same first two decimals is equal even though the third decimal changes. This PR introduce this tolerance when validating input sampling rates in subtract_projection and volume_consensus protocols. @albertmena @pconesa should be this reviewed and considered in validation step of other protocols? (as long as it is checked that the program that is called by the protocol has no problems with this small differences in sampling rate)