### PR TITLE
Better instantiation of Scipion subclasses

### DIFF
--- a/xmipp3/protocols/protocol_preprocess/protocol_process.py
+++ b/xmipp3/protocols/protocol_preprocess/protocol_process.py
@@ -87,7 +87,7 @@ class XmippProcessParticles(ProtProcessParticles):
         inputSet = self.inputParticles.get()
         # outputSet could be SetOfParticles, SetOfAverages or any future sub-class of SetOfParticles
         className = inputSet.getClassName()
-        outputSet = self._createSetFromName(className)
+        outputSet = inputSet.createCopy(self._getPath())
         outputSet.copyInfo(inputSet)
 
         self._preprocessOutput(outputSet)


### PR DESCRIPTION
instatiate Scipion subclasses directly from an input object instead of searching for the corresponding _createSetOf method, as the previous function might be defined in a Plugin not imported at execution time.