### PR TITLE
Renaming enviroment deepHand with pyTorch

### DIFF
--- a/xmipp3/protocols/protocol_deep_hand.py
+++ b/xmipp3/protocols/protocol_deep_hand.py
@@ -39,7 +39,7 @@ class XmippProtDeepHand(EMProtocol, XmippProtocol):
     """
 
     _label ="deep hand"
-    _conda_env = "xmipp_deepHand"
+    _conda_env = "xmipp_pyTorch"
 
     def __init__(self, *args, **kwargs):
         EMProtocol.__init__(self, *args, **kwargs)


### PR DESCRIPTION
With the new naming, the environment is more generalist and could be used by other protocols (as maybe the one of Erney).
See also https://github.com/I2PC/xmipp/pull/750