### PR TITLE
protocol_consensus_local_ctf: save defocus in proper fields

### DIFF
--- a/xmipp3/protocols/protocol_consensus_local_ctf.py
+++ b/xmipp3/protocols/protocol_consensus_local_ctf.py
@@ -37,7 +37,6 @@ from pwem import emlib
 
 from xmipp3.convert import setXmippAttribute
 
-
 class XmippProtConsensusLocalCTF(ProtAnalysis3D):
     """This protocol compares the estimations of local defocus computed by different protocols for a set of particles"""
     _label = 'consensus local defocus'
@@ -60,8 +59,8 @@ class XmippProtConsensusLocalCTF(ProtAnalysis3D):
 
     #--------------------------- INSERT steps functions --------------------------------------------
     def _insertAllSteps(self):
-        self._insertFunctionStep("compareDefocus")
-        self._insertFunctionStep("createOutputStep")
+        self._insertFunctionStep(self.compareDefocus)
+        self._insertFunctionStep(self.createOutputStep)
 
     #--------------------------- STEPS functions ---------------------------------------------------
     def compareDefocus(self):

--- a/xmipp3/protocols/protocol_consensus_local_ctf.py
+++ b/xmipp3/protocols/protocol_consensus_local_ctf.py
@@ -34,13 +34,17 @@ from pyworkflow.protocol.params import MultiPointerParam, PointerParam
 
 from pwem.protocols import ProtAnalysis3D
 from pwem import emlib
+from pwem.objects import SetOfParticles
 
 from xmipp3.convert import setXmippAttribute
+
+OUTPUTNAME = "outputParticles"
 
 class XmippProtConsensusLocalCTF(ProtAnalysis3D):
     """This protocol compares the estimations of local defocus computed by different protocols for a set of particles"""
     _label = 'consensus local defocus'
     _lastUpdateVersion = VERSION_2_0
+    _possibleOutputs = {OUTPUTNAME:SetOfParticles}
 
     def __init__(self, **args):
         ProtAnalysis3D.__init__(self, **args)
@@ -121,7 +125,7 @@ class XmippProtConsensusLocalCTF(ProtAnalysis3D):
                 setXmippAttribute(newPart.getCTF(), emlib.MDL_CTF_DEFOCUS_RESIDUAL, pMad)
                 outputSet.append(newPart)
 
-        self._defineOutputs(outputParticles=outputSet)
+        self._defineOutputs(**{OUTPUTNAME:outputSet})
         self._defineSourceRelation(self.inputSet, outputSet)
 
 
@@ -134,7 +138,7 @@ class XmippProtConsensusLocalCTF(ProtAnalysis3D):
     #--------------------------- INFO functions --------------------------------------------
     def _summary(self):
         summary = []
-        summary.append("Consensus local defocus and residual computed for %s particles" % self.getObjectTag('outputParticles'))
+        summary.append("Consensus local defocus and residual computed for %s particles" % self.getObjectTag(OUTPUTNAME))
         return summary
 
     def _methods(self):

--- a/xmipp3/protocols/protocol_consensus_local_ctf.py
+++ b/xmipp3/protocols/protocol_consensus_local_ctf.py
@@ -117,7 +117,8 @@ class XmippProtConsensusLocalCTF(ProtAnalysis3D):
                 newPart = part.clone()
                 pMedian = Float(self.median[index])
                 pMad = Float(self.mad[index])
-                setXmippAttribute(newPart.getCTF(), emlib.MDL_CTF_DEFOCUSA, pMedian)
+                newPart._ctfModel._defocusU.set(pMedian)
+                newPart._ctfModel._defocusV.set(pMedian)
                 setXmippAttribute(newPart.getCTF(), emlib.MDL_CTF_DEFOCUS_RESIDUAL, pMad)
                 outputSet.append(newPart)
 


### PR DESCRIPTION
consensus local defocus estimation was saved in an xmipp field and thus, following reconstruction programs did not read that value when computing reconstructions. Thus, now the consensus local defocus estimation is saved directly in fileds defocusU and defocusV of the generic ctfModel.