### PR TITLE
Fix: Manual viewer not working when prunning is disabled

### DIFF
--- a/xmipp3/protocols/protocol_consensus_classes.py
+++ b/xmipp3/protocols/protocol_consensus_classes.py
@@ -527,7 +527,10 @@ class XmippProtConsensusClasses(ProtClassify3D):
         else:
             # Load from input
             SetOfImagesSubtype = self._getSetOfImagesSubtype()
-            images = SetOfImagesSubtype(filename=self._getOutputImagesSqliteFilename(self._getImagesSuffix()))
+            if os.path.exists(self._getOutputImagesSqliteFilename(self._getImagesSuffix())):
+                images = SetOfImagesSubtype(filename=self._getOutputImagesSqliteFilename(self._getImagesSuffix()))
+            else:
+                images = self._getInputImages()
             classifications = self._getInputClassifications()
             intersections = self._getOutputIntersectionIds()
             linkage = self._readLinkageMatrix()


### PR DESCRIPTION
I detected an error in the 3D classification protocol which prevents it from opening a manual number of images from the viewer. 