### PR TITLE
Fixed requirements.txt format

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 scipion-pyworkflow>=3.0.31
-scikit-learn=0.22
+scikit-learn==0.22
 scipion-em
 scipy<=1.10.0
 joblib


### PR DESCRIPTION
Single `=` crashes command `pip install -r requirements.txt`