### PR TITLE
protocol xmipp-movie-gain: np.asscalar discontinued in numpy 1.16

### DIFF
--- a/xmipp3/protocols/protocol_movie_gain.py
+++ b/xmipp3/protocols/protocol_movie_gain.py
@@ -407,13 +407,19 @@ class XmippProtMovieGain(ProtProcessMovies):
                     best_cor = minVal
                     best_transf = (angle,imir)
                     best_R = R
-                    T = np.asarray([[1, 0, np.asscalar(corLoc[1])], [0, 1, np.asscalar(corLoc[0])], [0, 0, 1]])
+                    # T = np.asarray([[1, 0, np.asscalar(corLoc[1])], [0, 1, np.asscalar(corLoc[0])], [0, 0, 1]])
+                    T = np.asarray([[1, 0, corLoc[1].item()],
+                                    [0, 1, corLoc[0].item],
+                                    [0, 0, 1]])
                 if abs(maxVal) > abs(best_cor):
                     corLoc = translation_correction(maxLoc, est_gain_array.shape)
                     best_cor = maxVal
                     best_transf = (angle, imir)
                     best_R = R
-                    T = np.asarray([[1, 0, np.asscalar(corLoc[1])], [0, 1, np.asscalar(corLoc[0])], [0, 0, 1]])
+                    # T = np.asarray([[1, 0, np.asscalar(corLoc[1])], [0, 1, np.asscalar(corLoc[0])], [0, 0, 1]])
+                    T = np.asarray([[1, 0, corLoc[1].item()], 
+                                    [0, 1, corLoc[0].item()],
+                                    [0, 0, 1]])
 
         # Multiply by inverse of translation matrix
         best_M = np.matmul(np.linalg.inv(T), best_R)

--- a/xmipp3/protocols/protocol_movie_gain.py
+++ b/xmipp3/protocols/protocol_movie_gain.py
@@ -409,7 +409,7 @@ class XmippProtMovieGain(ProtProcessMovies):
                     best_R = R
                     # T = np.asarray([[1, 0, np.asscalar(corLoc[1])], [0, 1, np.asscalar(corLoc[0])], [0, 0, 1]])
                     T = np.asarray([[1, 0, corLoc[1].item()],
-                                    [0, 1, corLoc[0].item],
+                                    [0, 1, corLoc[0].item()],
                                     [0, 0, 1]])
                 if abs(maxVal) > abs(best_cor):
                     corLoc = translation_correction(maxLoc, est_gain_array.shape)


### PR DESCRIPTION
 the method np.asscalar(a) is deprecated since NumPy v1.16. Since scipion is using v1.23. the protocol does not work any longer. The function np.asscalar(a) need to be  replaced by a.item()