### PR TITLE
protocol_consensus_local_ctf: add consensus angle

### DIFF
--- a/xmipp3/protocols/protocol_local_ctf.py
+++ b/xmipp3/protocols/protocol_local_ctf.py
@@ -65,7 +65,7 @@ class XmippProtLocalCTF(ProtAnalysis3D):
         form.addParam('maxGrayShiftChange', FloatParam, label="Maximum gray shift change", default=1,
                       expertLevel=LEVEL_ADVANCED, help="The reprojection is modified as a*P+b, b is restricted to the "
                                                        "interval [-maxGrayShift,maxGrayShift]")
-        form.addParam('sameDefocus', BooleanParam, label="Force defocusV to be equal than defocusU", default=True,
+        form.addParam('sameDefocus', BooleanParam, label="Force defocusV to be equal than defocusU", default=False,
                       expertLevel=LEVEL_ADVANCED,
                       help="As the CTF usually suffers from astigmatism (it is not spherical but ellipsoidal), the "
                            "defocus vary if computed in X or Y direction, being defocus U value the defocus in X "

--- a/xmipp3/protocols/protocol_simulate_ctf.py
+++ b/xmipp3/protocols/protocol_simulate_ctf.py
@@ -67,6 +67,20 @@ class XmippProtSimulateCTF(Prot2D):
         form.addParam('DefocusF', params.FloatParam, default=25000,
                       label="Upper defocus (A)",
                       help="Negative value is overfocus")
+        form.addParam('astig', params.BooleanParam, default=False,
+                      label="Simulate astigmatic CTF?",
+                      help="If yes, defocusU and defocusV will have different values with a difference determined by"
+                           " the user, and there will be a value for angle")
+        form.addParam('angle0', params.FloatParam, default=40, condition='astig',
+                      label="Lower defocus angle (degrees)",
+                      help="Between 0 and 90")
+        form.addParam('angleF', params.FloatParam, default=50, condition='astig',
+                      label="Upper defocus angle (degrees)",
+                      help="Between 0 and 90")
+        form.addParam('Defocus0diff', params.FloatParam, default=-500, condition='astig',
+                      label="Lower defocus difference between defocusU and defocusV (A)")
+        form.addParam('DefocusFdiff', params.FloatParam, default=500, condition='astig',
+                      label="Upper defocus difference between defocusU and defocusV(A)")
 
     # --------------------------- INSERT steps functions ------------------------
     def _insertAllSteps(self):
@@ -97,15 +111,24 @@ class XmippProtSimulateCTF(Prot2D):
             location = particle.getLocation()
             fnIn = str(location[0]) + "@" + location[1]
             fnOut = str(n) + "@" + fnStk
-            defocus = random.uniform(self.Defocus0.get(), self.DefocusF.get())
+            defocusU = random.uniform(self.Defocus0.get(), self.DefocusF.get())
             args = "-i %s -o %s" % (fnIn, fnOut)
-            args += " --fourier ctfdef %f %f %f %f --sampling %f -v 0" % (self.voltage, self.cs, self.Q0, defocus, Ts)
+            if self.astig:
+                defocusV = defocusU + random.uniform(self.Defocus0diff.get(), self.DefocusFdiff.get())
+                defocusAngle = random.uniform(self.angle0.get(), self.angleF.get())
+                args += " --fourier ctfdefastig %f %f %f %f %f %f --sampling %f -v 0" % \
+                        (self.voltage, self.cs, self.Q0, defocusU, defocusV, defocusAngle, Ts)
+            else:
+                defocusV = defocusU
+                defocusAngle = 0
+                args += " --fourier ctfdef %f %f %f %f  --sampling %f -v 0" % \
+                        (self.voltage, self.cs, self.Q0, defocusU, Ts)
             self.runJob("xmipp_transform_filter", args)
 
             newCTF = CTFModel()
-            newCTF.setDefocusU(defocus)
-            newCTF.setDefocusV(defocus)
-            newCTF.setDefocusAngle(0.0)
+            newCTF.setDefocusU(defocusU)
+            newCTF.setDefocusV(defocusV)
+            newCTF.setDefocusAngle(defocusAngle)
             newParticle = particle.clone()
             newParticle.setLocation((n, fnStk))
             acquisition = newParticle.getAcquisition()

--- a/xmipp3/tests/test_protocol_simulate_ctf.py
+++ b/xmipp3/tests/test_protocol_simulate_ctf.py
@@ -32,7 +32,7 @@ import pyworkflow.utils as pwutils
 from pwem.protocols import ProtImportVolumes
 from xmipp3.protocols import XmippProtSimulateCTF, XmippProtCreateGallery
 
-
+OUTPARTERROR = "There was a problem with particles output"
 class TestXmippProtSimulateCTF(BaseTest):
     """ Testing CTF simulation
     """
@@ -90,9 +90,9 @@ class TestXmippProtSimulateCTF(BaseTest):
         # Check default defoci values
         projectionsCTFDefault = self.runSimulateCTF(projectionsGallery)
         self.assertTrue(projectionsCTFDefault,
-                        "There was a problem with particles output")
+                        OUTPARTERROR)
         self.assertEqual(projectionsCTFDefault.getSize(),1647,
-                        "There was a problem with particles output")
+                        OUTPARTERROR)
         self.assertEqual(projectionsCTFDefault.getXDim(),60,
                         "Unexpected particle size in output particles")
         self.assertEqual(projectionsCTFDefault.getSamplingRate(),1,
@@ -114,9 +114,9 @@ class TestXmippProtSimulateCTF(BaseTest):
         # Check default defoci values
         projectionsCTFDefaultAstig = self.runSimulateCTFAstig(projectionsGallery)
         self.assertTrue(projectionsCTFDefaultAstig,
-                        "There was a problem with particles output")
+                        OUTPARTERROR)
         self.assertEqual(projectionsCTFDefaultAstig.getSize(),1647,
-                        "There was a problem with particles output")
+                        OUTPARTERROR)
         self.assertEqual(projectionsCTFDefaultAstig.getXDim(),60,
                         "Unexpected particle size in output particles")
         self.assertEqual(projectionsCTFDefaultAstig.getSamplingRate(),1,

--- a/xmipp3/tests/test_protocols_local_defocus.py
+++ b/xmipp3/tests/test_protocols_local_defocus.py
@@ -52,7 +52,8 @@ class TestXmippLocalDefocusEstimation(BaseTest):
 
         protEstimateLocalDefocus = self.newProtocol(XmippProtLocalCTF,
                                                     inputSet=protSimulateCTF.outputParticles,
-                                                    inputVolume=self.protCreatePhantom.outputVolume)
+                                                    inputVolume=self.protCreatePhantom.outputVolume,
+                                                    sameDefocus=True)
         self.launchProtocol(protEstimateLocalDefocus)
         self.assertIsNotNone(protEstimateLocalDefocus.outputParticles.getFiles(),
                              "There was a problem with local CTF estimation")
@@ -70,7 +71,8 @@ class TestXmippLocalDefocusEstimationConsensus(TestXmippLocalDefocusEstimation):
 
     def testXmippLocalDefocusConsensus(self):
         protSimulateCTF2 = self.newProtocol(XmippProtSimulateCTF,
-                                            inputParticles=self.protCreateGallery.outputReprojections)
+                                            inputParticles=self.protCreateGallery.outputReprojections,
+                                            astig=True)
         self.launchProtocol(protSimulateCTF2)
         self.assertIsNotNone(protSimulateCTF2.outputParticles, "There was a problem with second CTF simulation")
 
@@ -82,7 +84,8 @@ class TestXmippLocalDefocusEstimationConsensus(TestXmippLocalDefocusEstimation):
                              "There was a problem with second CTF estimation")
 
         protSimulateCTF3 = self.newProtocol(XmippProtSimulateCTF,
-                                            inputParticles=self.protCreateGallery.outputReprojections)
+                                            inputParticles=self.protCreateGallery.outputReprojections,
+                                            astig=True)
         self.launchProtocol(protSimulateCTF3)
         self.assertIsNotNone(protSimulateCTF3.outputParticles, "There was a problem with third CTF simulation")
 


### PR DESCRIPTION
- Add defocus angle consensus to `protocol consensus local ctf` (similar to last modification for adding consensus for defocusV)
- Modify default parameter in `protocol local defocus estimate`
- Add posibility to simulate astigmatic CTF to `protocol simulate ctf` (in order to better test `protocol_consensus_local_ctf`)
- Fix corresponding `tests` according to these modifications