### PR TITLE
DeepCenter: New protocols

### DIFF
--- a/xmipp3/protocols/__init__.py
+++ b/xmipp3/protocols/__init__.py
@@ -138,3 +138,7 @@ from .protocol_volume_adjust_sub import XmippProtVolAdjust, XmippProtVolSubtract
 from .protocol_volume_consensus import XmippProtVolConsensus
 from .protocol_classes_2d_mapping import XmippProtCL2DMap
 from .protocol_deep_hand import XmippProtDeepHand
+from .protocol_deep_center import XmippProtDeepCenter
+from .protocol_deep_center_predict import XmippProtDeepCenterPredict
+from .protocol_deep_global_assignment import XmippProtDeepGlobalAssignment
+from .protocol_deep_global_assignment_predict import XmippProtDeepGlobalAssignmentPredict

--- a/xmipp3/protocols/protocol_deep_center.py
+++ b/xmipp3/protocols/protocol_deep_center.py
@@ -51,7 +51,7 @@ class XmippProtDeepCenter(ProtAlign2D, xmipp3.XmippProtocol):
        to a volume, and they must have 3D alignment information. """
     _label = 'deep center'
     _lastUpdateVersion = VERSION_3_0
-    _conda_env = 'xmipp_DLTK_v0.3'
+    _conda_env = 'xmipp_DLTK_v1.0'
     _cond_modelPretrainTrue = 'modelPretrain==True'
     _cond_modelPretrainFalse = 'modelPretrain==False'
 

--- a/xmipp3/protocols/protocol_deep_center.py
+++ b/xmipp3/protocols/protocol_deep_center.py
@@ -1,0 +1,172 @@
+# **************************************************************************
+# *
+# * Authors:     COS Sorzano and Adrian Sansinena
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+
+from pyworkflow import VERSION_3_0
+from pyworkflow.protocol import STEPS_PARALLEL
+from pyworkflow.protocol.params import (PointerParam, StringParam, FloatParam, EnumParam,
+                                        IntParam, BooleanParam, GPU_LIST)
+from pyworkflow.protocol.constants import LEVEL_ADVANCED
+from pyworkflow.utils.path import moveFile, cleanPattern
+from pwem.protocols import ProtAlign2D
+from pwem.emlib.metadata import iterRows, getFirstRow
+import pwem.emlib.metadata as md
+from xmipp3.convert import createItemMatrix, setXmippAttributes, readSetOfParticles, writeSetOfParticles
+from pwem import ALIGN_PROJ
+from pwem import emlib
+from pwem.emlib.image import ImageHandler
+import os
+import sys
+import numpy as np
+import math
+from shutil import copy
+from os import remove
+from os.path import exists, join
+import xmipp3
+
+class XmippProtDeepCenter(ProtAlign2D, xmipp3.XmippProtocol):
+    """Learns a model to center particles using deep learning. Particles must be previously centered with respect
+       to a volume, and they must have 3D alignment information. """
+    _label = 'deep center'
+    _lastUpdateVersion = VERSION_3_0
+    _conda_env = 'xmipp_DLTK_v0.3'
+    _cond_modelPretrainTrue = 'modelPretrain==True'
+    _cond_modelPretrainFalse = 'modelPretrain==False'
+
+
+    def __init__(self, **args):
+        ProtAlign2D.__init__(self, **args)
+    # --------------------------- DEFINE param functions --------------------------------------------
+    def _defineParams(self, form):
+        form.addHidden(GPU_LIST, StringParam, default='0',
+                       expertLevel=LEVEL_ADVANCED,
+                       label="Choose GPU IDs",
+                       help="GPU may have several cores. Set it to zero"
+                            " if you do not know what we are talking about."
+                            " First core index is 0, second 1 and so on.")
+        form.addSection(label='Input')
+        form.addParam('inputTrainSet', PointerParam, label="Input training set",
+                      pointerClass='SetOfParticles',
+                      pointerCondition='hasAlignment2D or hasAlignmentProj',
+                      help='The set of particles previously aligned to be used as training set')
+
+        form.addParam('Xdim', IntParam, label="Size of the images for training", default=128)
+
+        form.addParam('modelPretrain', BooleanParam, default=False,
+                      label='Choose if you want to use a pretrained model',
+                      help='Set "yes" if you want to use a previously trained model. '
+                           'If you choose "no" new models will be trained.')
+
+        form.addParam('pretrainedModels', PointerParam,
+                      pointerClass='XmippProtDeepCenter',
+                      condition=self._cond_modelPretrainTrue,
+                      label='Pretrained model',
+                      help='Select the pretrained model. ')
+
+        form.addSection(label='Training parameters')
+        form.addParam('numCenModels', IntParam,
+                      label="Number of models for particle centering", default=5,
+                      help="Choose number of models you want to train. More than 1 is recommended only if next step "
+                           "is inference.")
+
+        form.addParam('numEpochs_cen', IntParam,
+                      label="Number of epochs",
+                      default=25, expertLevel=LEVEL_ADVANCED,
+                      help="Number of epochs for training.")
+
+        form.addParam('batchSize', IntParam,
+                      label="Batch size for training",
+                      default=32, expertLevel=LEVEL_ADVANCED,
+                      help="Batch size for training.")
+
+        form.addParam('learningRate', FloatParam,
+                      label="Learning rate",
+                      default=0.001, expertLevel=LEVEL_ADVANCED,
+                      help="Learning rate for training.")
+
+        form.addParam('sigma', FloatParam,
+                      label="Image shifting",
+                      default=10, expertLevel=LEVEL_ADVANCED,
+                      help="A measure of the number of pixels that particles can be shifted in each direction from the center.")
+
+        form.addParam('patience', IntParam,
+                      label="Patience",
+                      default=5, expertLevel=LEVEL_ADVANCED,
+                      help="Training will be stopped if the number of epochs without improvement is greater than "
+                           "patience.")
+
+        form.addParallelSection(threads=1, mpi=1)
+
+    # --------------------------- INSERT steps functions --------------------------------------------
+    def _insertAllSteps(self):
+        self.trainImgsFn = self._getExtraPath('train_input_imgs.xmd')
+        if self.useQueueForSteps() or self.useQueue():
+            myStr = os.environ["CUDA_VISIBLE_DEVICES"]
+        else:
+            myStr = self.gpuList.get()
+            os.environ["CUDA_VISIBLE_DEVICES"] = self.gpuList.get()
+        numGPU = myStr.split(',')
+
+        self._insertFunctionStep("convertStep")
+        self._insertFunctionStep("train", numGPU[0])
+
+    # --------------------------- STEPS functions ---------------------------------------------------
+    def convertStep(self):
+        writeSetOfParticles(self.inputTrainSet.get(), self.trainImgsFn)
+        self.runJob("xmipp_image_resize",
+                    "-i %s -o %s --save_metadata_stack %s --fourier %d" %
+                    (self.trainImgsFn,
+                        self._getExtraPath('trainingResized.stk'),
+                        self._getExtraPath('trainingResized.xmd'),
+                        self.Xdim), numberOfMpi=self.numberOfThreads.get()*self.numberOfMpi.get())
+
+    def train(self, gpuId):
+
+        sig = self.sigma.get()
+
+        self.pretrained = 'no'
+        self.pathToModel = 'none'
+        if self.modelPretrain:
+            self.model = self.pretrainedModels.get()
+            self.pretrained = 'yes'
+            self.pathToModel = self.model._getExtraPath("modelCenter0.h5")
+
+        args = "%s %s %f %d %d %s %d %f %d %s %s" % (
+            self._getExtraPath("trainingResized.xmd"), self._getExtraPath("modelCenter"), sig,
+            self.numEpochs_cen, self.batchSize.get(), gpuId, self.numCenModels.get(), self.learningRate.get(),
+            self.patience.get(), self.pretrained, self.pathToModel)
+        print(args)
+        self.runJob("xmipp_deep_center", args, numberOfMpi=1, env=self.getCondaEnv())
+
+        remove(self._getExtraPath("trainingResized.xmd"))
+        remove(self._getExtraPath("trainingResized.stk"))
+
+    # --------------------------- INFO functions --------------------------------
+    def _methods(self):
+        methods = []
+        if hasattr(self, 'outputParticles'):
+            methods.append("We learned a model to center particles from %i input images (%s)." \
+                % (self.inputSet.get().getSize(), self.getObjectTag('inputSet')))
+        return methods

--- a/xmipp3/protocols/protocol_deep_center_predict.py
+++ b/xmipp3/protocols/protocol_deep_center_predict.py
@@ -50,7 +50,7 @@ class XmippProtDeepCenterPredict(ProtAlign2D, xmipp3.XmippProtocol):
     """Predict the center particles using deep learning.""" 
     _label = 'deep center predict'
     _lastUpdateVersion = VERSION_3_0
-    _conda_env = 'xmipp_DLTK_v0.3'
+    _conda_env = 'xmipp_DLTK_v1.0'
     _cond_predictAnglesTrue = 'predictAngles==True'
     _cond_predictAnglesFalse = 'predictAngles==False'
     _cond_trainedModelTrue = 'trainedModel==True'

--- a/xmipp3/protocols/protocol_deep_center_predict.py
+++ b/xmipp3/protocols/protocol_deep_center_predict.py
@@ -1,0 +1,155 @@
+# **************************************************************************
+# *
+# * Authors:     COS Sorzano, Erney Ramirez and Adrian Sansinena
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+
+from pyworkflow import VERSION_3_0
+from pyworkflow.protocol import STEPS_PARALLEL
+from pyworkflow.protocol.params import (PointerParam, StringParam, FloatParam,
+                                        IntParam, BooleanParam, GPU_LIST, EnumParam)
+from pyworkflow.protocol.constants import LEVEL_ADVANCED
+from pyworkflow.utils.path import moveFile, cleanPattern
+from pwem.protocols import ProtAlign2D
+from pwem.emlib.metadata import iterRows, getFirstRow
+import pwem.emlib.metadata as md
+from xmipp3.convert import createItemMatrix, setXmippAttributes, readSetOfParticles, writeSetOfParticles
+from pwem import ALIGN_PROJ
+from pwem import emlib
+from pwem.emlib.image import ImageHandler
+import os
+import sys
+import numpy as np
+import math
+from shutil import copy
+from os import remove
+from os.path import exists, join
+import xmipp3
+
+class XmippProtDeepCenterPredict(ProtAlign2D, xmipp3.XmippProtocol):
+    """Predict the center particles using deep learning.""" 
+    _label = 'deep center predict'
+    _lastUpdateVersion = VERSION_3_0
+    _conda_env = 'xmipp_DLTK_v0.3'
+    _cond_predictAnglesTrue = 'predictAngles==True'
+    _cond_predictAnglesFalse = 'predictAngles==False'
+    _cond_trainedModelTrue = 'trainedModel==True'
+    _cond_trainedModelFalse = 'trainedModel==False'
+    _cond_needModel = '(trainedModel==True) or (predictAngles==True)'
+
+    def __init__(self, **args):
+        ProtAlign2D.__init__(self, **args)
+
+    # --------------------------- DEFINE param functions --------------------------------------------
+    def _defineParams(self, form):
+
+        form.addHidden(GPU_LIST, StringParam, default='0',
+                       expertLevel=LEVEL_ADVANCED,
+                       label="Choose GPU IDs",
+                       help="GPU may have several cores. Set it to zero"
+                            " if you do not know what we are talking about."
+                            " First core index is 0, second 1 and so on.")
+
+        form.addSection(label='Input')
+
+        form.addParam('inputImageSet', PointerParam, label="Input Image set",
+                      pointerClass='SetOfParticles',
+                      help='The set of particles to predict shift')
+
+        form.addParam('Xdim', IntParam, label="Size of the images for training", default=128)
+
+        form.addParam('inputModel', PointerParam, label="Model trained",
+                      pointerClass='XmippProtDeepCenter',
+                      help='The model to predict angles')
+
+        form.addSection(label='Consensus')
+
+        form.addParam('numModels', IntParam,
+                      label="Number of models trained", default=5)
+
+        form.addParam('tolerance', IntParam,
+                      label="Tolerance in pixels", default=3,
+                      help="Max difference between predictions and their mean value.")
+
+        form.addParam('maxModels', IntParam,
+                      label="Maximum number of models dropped per particle", default=0,
+                      help="If more models are dropped, the particle is discarded.")
+
+        form.addParallelSection(threads=1, mpi=1)
+
+    # --------------------------- INSERT steps functions --------------------------------------------
+    def _insertAllSteps(self):
+        self.predictImgsFn = self._getExtraPath('predict_input_imgs.xmd')
+
+        if self.useQueueForSteps() or self.useQueue():
+            myStr = os.environ["CUDA_VISIBLE_DEVICES"]
+        else:
+            myStr = self.gpuList.get()
+            os.environ["CUDA_VISIBLE_DEVICES"] = self.gpuList.get()
+        numGPU = myStr.split(',')
+
+        self._insertFunctionStep("convertStep")
+        self._insertFunctionStep("predict", numGPU[0])
+        self._insertFunctionStep('createOutputStep')
+
+    # --------------------------- STEPS functions ---------------------------------------------------
+    def convertStep(self):
+        writeSetOfParticles(self.inputImageSet.get(), self.predictImgsFn)
+        self.runJob("xmipp_image_resize",
+                    "-i %s -o %s --save_metadata_stack %s --fourier %d" %
+                    (self.predictImgsFn,
+                        self._getExtraPath('trainingResized.stk'),
+                        self._getExtraPath('trainingResized.xmd'),
+                        self.Xdim), numberOfMpi=self.numberOfThreads.get()*self.numberOfMpi.get())
+
+    def predict(self, gpuId):
+        self.modelAng = self.inputModel.get()
+        args = "%s %s %s %s %s %d %d %d" % (
+            self._getExtraPath("trainingResized.xmd"), gpuId, self._getPath(), self.predictImgsFn,
+            self.modelAng._getExtraPath("modelCenter"), self.numModels.get(), self.tolerance.get(),
+            self.maxModels.get())
+
+        self.runJob("xmipp_deep_center_predict", args, numberOfMpi=1, env=self.getCondaEnv())
+
+        remove(self._getExtraPath("trainingResized.xmd"))
+        remove(self._getExtraPath("trainingResized.stk"))
+
+    def createOutputStep(self):
+        imgFname = self._getPath('predict_results.xmd')
+        outputSet = self._createSetOfParticles()
+
+        readSetOfParticles(imgFname, outputSet)
+        outputSet.copyInfo(self.inputImageSet.get())
+        outputSet.setAlignmentProj()
+
+        self._defineOutputs(outputParticles=outputSet)
+        self._store(outputSet)
+        self._defineSourceRelation(self.inputImageSet.get(), outputSet)
+
+    # --------------------------- INFO functions --------------------------------
+    def _methods(self):
+        methods = []
+        if hasattr(self, 'outputParticles'):
+            methods.append("We learned a model to center particles from %i input images (%s)." \
+                % (self.inputSet.get().getSize(), self.getObjectTag('inputSet')))
+        return methods

--- a/xmipp3/protocols/protocol_deep_global_assignment.py
+++ b/xmipp3/protocols/protocol_deep_global_assignment.py
@@ -52,7 +52,7 @@ class XmippProtDeepGlobalAssignment(ProtAlign2D, xmipp3.XmippProtocol):
        to a volume, and they must have 3D alignment information. """
     _label = 'deep global assignment'
     _lastUpdateVersion = VERSION_3_0
-    _conda_env = 'xmipp_DLTK_v0.3'
+    _conda_env = 'xmipp_DLTK_v1.0'
     _cond_modelPretrainTrue = 'modelPretrain==True'
     _cond_modelPretrainFalse = 'modelPretrain==False'
 

--- a/xmipp3/protocols/protocol_deep_global_assignment.py
+++ b/xmipp3/protocols/protocol_deep_global_assignment.py
@@ -1,0 +1,173 @@
+# **************************************************************************
+# *
+# * Authors:     COS Sorzano and Adrian Sansinena
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+
+from pyworkflow import VERSION_3_0
+from pyworkflow.protocol import STEPS_PARALLEL
+from pyworkflow.protocol.params import (PointerParam, StringParam, FloatParam, EnumParam,
+                                        IntParam, BooleanParam, GPU_LIST)
+from pyworkflow.protocol.constants import LEVEL_ADVANCED
+from pyworkflow.utils.path import moveFile, cleanPattern
+from pwem.protocols import ProtAlign2D
+from pwem.emlib.metadata import iterRows, getFirstRow
+import pwem.emlib.metadata as md
+from xmipp3.convert import createItemMatrix, setXmippAttributes, readSetOfParticles, writeSetOfParticles
+from pwem import ALIGN_PROJ
+from pwem import emlib
+from pwem.emlib.image import ImageHandler
+import os
+import sys
+import numpy as np
+import math
+from shutil import copy
+from os import remove
+from os.path import exists, join
+import xmipp3
+
+
+class XmippProtDeepGlobalAssignment(ProtAlign2D, xmipp3.XmippProtocol):
+    """Learns a model to assign angles to particles using deep learning. Particles must be previously centered with respect
+       to a volume, and they must have 3D alignment information. """
+    _label = 'deep global assignment'
+    _lastUpdateVersion = VERSION_3_0
+    _conda_env = 'xmipp_DLTK_v0.3'
+    _cond_modelPretrainTrue = 'modelPretrain==True'
+    _cond_modelPretrainFalse = 'modelPretrain==False'
+
+    def __init__(self, **args):
+        ProtAlign2D.__init__(self, **args)
+
+    # --------------------------- DEFINE param functions --------------------------------------------
+    def _defineParams(self, form):
+        form.addHidden(GPU_LIST, StringParam, default='0',
+                       expertLevel=LEVEL_ADVANCED,
+                       label="Choose GPU IDs",
+                       help="GPU may have several cores. Set it to zero"
+                            " if you do not know what we are talking about."
+                            " First core index is 0, second 1 and so on.")
+        form.addSection(label='Input')
+        form.addParam('inputTrainSet', PointerParam, label="Input training set",
+                      pointerClass='SetOfParticles',
+                      pointerCondition='hasAlignment2D or hasAlignmentProj',
+                      help='The set of particles previously aligned to be used as training set')
+
+        form.addParam('Xdim', IntParam, label="Size of the images for training", default=128)
+
+        form.addParam('modelPretrain', BooleanParam, default=False,
+                      label='Choose if you want to use a pretrained model',
+                      help='Set "yes" if you want to use a previously trained model. '
+                           'If you choose "no" new models will be trained.')
+
+        form.addParam('pretrainedModels', PointerParam,
+                      pointerClass='XmippProtDeepGlobalAssignment',
+                      condition=self._cond_modelPretrainTrue,
+                      label='Pretrained model',
+                      help='Select the pretrained model. ')
+
+        form.addSection(label='Training parameters')
+        form.addParam('numAngModels', IntParam,
+                      label="Number of models for angular assignment", default=5,
+                      help="Choose number of models you want to train. More than 1 is recommended only if next step "
+                           "is inference.")
+
+        form.addParam('numEpochs_ang', IntParam,
+                      label="Number of epochs",
+                      default=25, expertLevel=LEVEL_ADVANCED,
+                      help="Number of epochs for training.")
+
+        form.addParam('batchSize', IntParam,
+                      label="Batch size for training",
+                      default=32, expertLevel=LEVEL_ADVANCED,
+                      help="Batch size for training.")
+
+        form.addParam('learningRate', FloatParam,
+                      label="Learning rate",
+                      default=0.001, expertLevel=LEVEL_ADVANCED,
+                      help="Learning rate for training.")
+
+        form.addParam('sigma', FloatParam,
+                      label="Image shifting",
+                      default=2, expertLevel=LEVEL_ADVANCED,
+                      help="Maximum number of pixels that particles can be shifted in each direction from the center.")
+
+        form.addParam('patience', IntParam,
+                      label="Patience",
+                      default=20, expertLevel=LEVEL_ADVANCED,
+                      help="Training will be stopped if the number of epochs without improvement is greater than "
+                           "patience.")
+
+        form.addParallelSection(threads=1, mpi=1)
+
+    # --------------------------- INSERT steps functions --------------------------------------------
+    def _insertAllSteps(self):
+        self.trainImgsFn = self._getExtraPath('train_input_imgs.xmd')
+        if self.useQueueForSteps() or self.useQueue():
+            myStr = os.environ["CUDA_VISIBLE_DEVICES"]
+        else:
+            myStr = self.gpuList.get()
+            os.environ["CUDA_VISIBLE_DEVICES"] = self.gpuList.get()
+        numGPU = myStr.split(',')
+
+        self._insertFunctionStep("convertStep")
+        self._insertFunctionStep("train", numGPU[0])
+
+    # --------------------------- STEPS functions ---------------------------------------------------
+    def convertStep(self):
+        writeSetOfParticles(self.inputTrainSet.get(), self.trainImgsFn)
+        self.runJob("xmipp_image_resize",
+                    "-i %s -o %s --save_metadata_stack %s --fourier %d" %
+                    (self.trainImgsFn,
+                     self._getExtraPath('trainingResized.stk'),
+                     self._getExtraPath('trainingResized.xmd'),
+                     self.Xdim), numberOfMpi=self.numberOfThreads.get() * self.numberOfMpi.get())
+
+    def train(self, gpuId):
+
+        sig = self.sigma.get()
+
+        self.pretrained = 'no'
+        self.pathToModel = 'none'
+        if self.modelPretrain:
+            self.model = self.pretrainedModels.get()
+            self.pretrained = 'yes'
+            self.pathToModel = self.model._getExtraPath("modelAngular0.h5")
+
+        args = "%s %s %f %d %d %s %d %f %d %s %s" % (
+            self._getExtraPath("trainingResized.xmd"), self._getExtraPath("modelAngular"), sig,
+            self.numEpochs_ang, self.batchSize.get(), gpuId, self.numAngModels.get(), self.learningRate.get(),
+            self.patience.get(), self.pretrained, self.pathToModel)
+        print(args)
+        self.runJob("xmipp_deep_global_assignment", args, numberOfMpi=1, env=self.getCondaEnv())
+
+        remove(self._getExtraPath("trainingResized.xmd"))
+        remove(self._getExtraPath("trainingResized.stk"))
+
+    # --------------------------- INFO functions --------------------------------
+    def _methods(self):
+        methods = []
+        if hasattr(self, 'outputParticles'):
+            methods.append("We learned a model to center particles from %i input images (%s)." \
+                           % (self.inputSet.get().getSize(), self.getObjectTag('inputSet')))
+        return methods

--- a/xmipp3/protocols/protocol_deep_global_assignment_predict.py
+++ b/xmipp3/protocols/protocol_deep_global_assignment_predict.py
@@ -1,0 +1,149 @@
+# **************************************************************************
+# *
+# * Authors:     COS Sorzano, Erney Ramirez and Adrian Sansinena
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+
+from pyworkflow import VERSION_3_0
+from pyworkflow.protocol import STEPS_PARALLEL
+from pyworkflow.protocol.params import (PointerParam, StringParam, FloatParam,
+                                        IntParam, BooleanParam, GPU_LIST, EnumParam)
+from pyworkflow.protocol.constants import LEVEL_ADVANCED
+from pyworkflow.utils.path import moveFile, cleanPattern
+from pwem.protocols import ProtAlign2D
+from pwem.emlib.metadata import iterRows, getFirstRow
+import pwem.emlib.metadata as md
+from xmipp3.convert import createItemMatrix, setXmippAttributes, readSetOfParticles, writeSetOfParticles
+from pwem import ALIGN_PROJ
+from pwem import emlib
+from pwem.emlib.image import ImageHandler
+import os
+import sys
+import numpy as np
+import math
+from shutil import copy
+from os import remove
+from os.path import exists, join
+import xmipp3
+
+
+class XmippProtDeepGlobalAssignmentPredict(ProtAlign2D, xmipp3.XmippProtocol):
+    """Predict the center particles using deep learning."""
+    _label = 'deep global assignment predict'
+    _lastUpdateVersion = VERSION_3_0
+    _conda_env = 'xmipp_DLTK_v0.3'
+
+    def __init__(self, **args):
+        ProtAlign2D.__init__(self, **args)
+
+    # --------------------------- DEFINE param functions --------------------------------------------
+    def _defineParams(self, form):
+
+        form.addHidden(GPU_LIST, StringParam, default='0',
+                       expertLevel=LEVEL_ADVANCED,
+                       label="Choose GPU IDs",
+                       help="GPU may have several cores. Set it to zero"
+                            " if you do not know what we are talking about."
+                            " First core index is 0, second 1 and so on.")
+        form.addSection(label='Input')
+
+        form.addParam('inputImageSet', PointerParam, label="Input Image set",
+                      pointerClass='SetOfParticles',
+                      help='The set of particles to predict shift')
+
+        form.addParam('Xdim', IntParam, label="Size of the images for training", default=128)
+
+        form.addParam('inputModel', PointerParam, label="Model trained",
+                      pointerClass='XmippProtDeepGlobalAssignment',
+                      help='The model to predict angles')
+
+        form.addSection(label='Consensus')
+
+        form.addParam('numAngModels', IntParam,
+                      label="Number of models trained", default=5)
+
+        form.addParam('tolerance', IntParam,
+                      label="Angular tolerance (º)", default=15,
+                      help="Max angular difference between predictions and their mean value.")
+
+        form.addParam('maxModels', IntParam,
+                      label="Maximum number of models dropped per particle", default=0,
+                      help="If more models are dropped, the particle is discarded.")
+
+        form.addParallelSection(threads=1, mpi=1)
+
+    # --------------------------- INSERT steps functions --------------------------------------------
+    def _insertAllSteps(self):
+        self.predictImgsFn = self._getExtraPath('predict_input_imgs.xmd')
+
+        if self.useQueueForSteps() or self.useQueue():
+            myStr = os.environ["CUDA_VISIBLE_DEVICES"]
+        else:
+            myStr = self.gpuList.get()
+            os.environ["CUDA_VISIBLE_DEVICES"] = self.gpuList.get()
+        numGPU = myStr.split(',')
+
+        self._insertFunctionStep("convertStep")
+        self._insertFunctionStep("predict", numGPU[0])
+        self._insertFunctionStep('createOutputStep')
+
+    # --------------------------- STEPS functions ---------------------------------------------------
+    def convertStep(self):
+        writeSetOfParticles(self.inputImageSet.get(), self.predictImgsFn)
+        self.runJob("xmipp_image_resize",
+                    "-i %s -o %s --save_metadata_stack %s --fourier %d" %
+                    (self.predictImgsFn,
+                     self._getExtraPath('trainingResized.stk'),
+                     self._getExtraPath('trainingResized.xmd'),
+                     self.Xdim), numberOfMpi=self.numberOfThreads.get() * self.numberOfMpi.get())
+
+    def predict(self, gpuId):
+        self.modelAng = self.inputModel.get()
+        args = "%s %s %s %s %s %d %d %d" % (
+            self._getExtraPath("trainingResized.xmd"), gpuId, self._getPath(), self.predictImgsFn,
+            self.modelAng._getExtraPath("modelAngular"), self.numAngModels.get(), self.tolerance.get(), self.maxModels.get())
+
+        self.runJob("xmipp_deep_global_assignment_predict", args, numberOfMpi=1, env=self.getCondaEnv())
+
+        remove(self._getExtraPath("trainingResized.xmd"))
+        remove(self._getExtraPath("trainingResized.stk"))
+
+    def createOutputStep(self):
+        imgFname = self._getPath('predict_results.xmd')
+        outputSet = self._createSetOfParticles()
+
+        readSetOfParticles(imgFname, outputSet)
+        outputSet.copyInfo(self.inputImageSet.get())
+        outputSet.setAlignmentProj()
+
+        self._defineOutputs(outputParticles=outputSet)
+        self._store(outputSet)
+        self._defineSourceRelation(self.inputImageSet.get(), outputSet)
+
+    # --------------------------- INFO functions --------------------------------
+    def _methods(self):
+        methods = []
+        if hasattr(self, 'outputParticles'):
+            methods.append("We learned a model to center particles from %i input images (%s)." \
+                           % (self.inputSet.get().getSize(), self.getObjectTag('inputSet')))
+        return methods

--- a/xmipp3/protocols/protocol_deep_global_assignment_predict.py
+++ b/xmipp3/protocols/protocol_deep_global_assignment_predict.py
@@ -51,7 +51,7 @@ class XmippProtDeepGlobalAssignmentPredict(ProtAlign2D, xmipp3.XmippProtocol):
     """Predict the center particles using deep learning."""
     _label = 'deep global assignment predict'
     _lastUpdateVersion = VERSION_3_0
-    _conda_env = 'xmipp_DLTK_v0.3'
+    _conda_env = 'xmipp_DLTK_v1.0'
 
     def __init__(self, **args):
         ProtAlign2D.__init__(self, **args)

--- a/xmipp3/tests/test_protocol_deep_center.py
+++ b/xmipp3/tests/test_protocol_deep_center.py
@@ -1,0 +1,109 @@
+# **************************************************************************
+# *
+# * Authors:    Adrian Sansinena Rodriguez  (adrian.sansinena@cnb.csic.es)
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+
+from pyworkflow.tests import BaseTest, DataSet, setupTestProject
+
+from pwem.protocols import (ProtImportParticles, ProtSubSet,
+                            exists)
+
+from pwem import emlib
+from xmipp3.protocols import XmippProtDeepCenter
+
+
+class TestDeepCenter(BaseTest):
+    @classmethod
+    def runImportParticles(cls):
+        """ Import Particles.
+        """
+        args = {'importFrom': ProtImportParticles.IMPORT_FROM_SCIPION,
+                'sqliteFile': cls.particles,
+                'amplitudConstrast': 0.1,
+                'sphericalAberration': 2.0,
+                'voltage': 200,
+                'samplingRate': 0.99,
+                'haveDataBeenPhaseFlipped': True
+                }
+
+        # Id's should be set increasing from 1 if ### is not in the
+        # pattern
+        protImport = cls.newProtocol(ProtImportParticles, **args)
+        protImport.setObjLabel('import particles')
+        cls.launchProtocol(protImport)
+        return protImport
+
+    @classmethod
+    def setUpClass(cls):
+        setupTestProject(cls)
+
+        # Data
+        cls.dataset = DataSet.getDataSet('10010')
+        cls.particles = cls.dataset.getFile('particles')
+
+        cls.protImportParts = cls.runImportParticles()
+
+    def test(self):
+        subset = self.newProtocol(ProtSubSet,
+                                  inputFullSet=self.protImportParts.outputParticles,
+                                  chooseAtRandom=True,
+                                  nElements=400)
+        self.launchProtocol(subset)
+
+        deepCenter = self.newProtocol(XmippProtDeepCenter,
+                                   inputTrainSet=subset.outputParticles,
+                                   Xdim=128,
+                                   modelPretrain=False,
+                                   numCenModels=5,
+                                   numEpochs_cen=1,
+                                   batchSize=32,
+                                   learningRate=0.001,
+                                   sigma=8,
+                                   patience=5)
+        self.launchProtocol(deepCenter)
+
+        fnModel0 = deepCenter._getExtraPath("modelCenter0.h5")
+        fnModel2 = deepCenter._getExtraPath("modelCenter2.h5")
+
+        if not exists(fnModel0):
+            self.assertTrue(False, fnModel0 + " does not exist")
+        if not exists(fnModel2):
+            self.assertTrue(False, fnModel2 + " does not exist")
+
+        deepCenter2 = self.newProtocol(XmippProtDeepCenter,
+                                      inputTrainSet=subset.outputParticles,
+                                      Xdim=128,
+                                      modelPretrain=True,
+                                      pretrainedModels=deepCenter,
+                                      numCenModels=5,
+                                      numEpochs_cen=10,
+                                      batchSize=32,
+                                      learningRate=0.001,
+                                      sigma=8,
+                                      patience=5)
+        self.launchProtocol(deepCenter2)
+
+        fnModel0 = deepCenter2._getExtraPath("modelCenter0.h5")
+        if not exists(fnModel0):
+            self.assertTrue(False, fnModel0 + " does not exist")

--- a/xmipp3/tests/test_protocol_deep_center_predict.py
+++ b/xmipp3/tests/test_protocol_deep_center_predict.py
@@ -1,0 +1,95 @@
+# **************************************************************************
+# *
+# * Authors:    Adrian Sansinena Rodriguez  (adrian.sansinena@cnb.csic.es)
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+
+from pyworkflow.tests import BaseTest, DataSet, setupTestProject
+
+from pwem.protocols import (ProtImportParticles, ProtSubSet,
+                            exists)
+
+from pwem import emlib
+from xmipp3.protocols import XmippProtDeepCenterPredict, XmippProtDeepCenter
+
+
+class TestDeepCenterPredict(BaseTest):
+    @classmethod
+    def runImportParticles(cls):
+        """ Import Particles.
+        """
+        args = {'importFrom': ProtImportParticles.IMPORT_FROM_SCIPION,
+                'sqliteFile': cls.particles,
+                'amplitudConstrast': 0.1,
+                'sphericalAberration': 2.0,
+                'voltage': 200,
+                'samplingRate': 0.99,
+                'haveDataBeenPhaseFlipped': True
+                }
+
+        protImport = cls.newProtocol(ProtImportParticles, **args)
+        protImport.setObjLabel('import particles')
+        cls.launchProtocol(protImport)
+        return protImport
+
+    @classmethod
+    def setUpClass(cls):
+        setupTestProject(cls)
+
+        # Data
+        cls.dataset = DataSet.getDataSet('10010')
+        cls.particles = cls.dataset.getFile('particles')
+
+        cls.protImportParts = cls.runImportParticles()
+
+    def test(self):
+        subset = self.newProtocol(ProtSubSet,
+                                  inputFullSet=self.protImportParts.outputParticles,
+                                  chooseAtRandom=True,
+                                  nElements=400)
+        self.launchProtocol(subset)
+
+        deepCenter = self.newProtocol(XmippProtDeepCenter,
+                                   inputTrainSet=subset.outputParticles,
+                                   Xdim=128,
+                                   modelPretrain=False,
+                                   numCenModels=5,
+                                   numEpochs_cen=1,
+                                   batchSize=32,
+                                   learningRate=0.001,
+                                   sigma=8,
+                                   patience=5)
+        self.launchProtocol(deepCenter)
+
+        deepCenterPredict = self.newProtocol(XmippProtDeepCenterPredict,
+                                      inputImageSet=subset.outputParticles,
+                                      Xdim=128,
+                                      inputModel=deepCenter,
+                                      numModels=5,
+                                      tolerance=2,
+                                      maxModels=1)
+        self.launchProtocol(deepCenterPredict)
+
+        self.assertIsNotNone(deepCenterPredict.outputParticles,
+                             "There was a problem with Deep Center Predict")
+

--- a/xmipp3/tests/test_protocol_deep_global_assignment.py
+++ b/xmipp3/tests/test_protocol_deep_global_assignment.py
@@ -1,0 +1,109 @@
+# **************************************************************************
+# *
+# * Authors:    Adrian Sansinena Rodriguez  (adrian.sansinena@cnb.csic.es)
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+
+from pyworkflow.tests import BaseTest, DataSet, setupTestProject
+
+from pwem.protocols import (ProtImportParticles, ProtSubSet,
+                            exists)
+
+from pwem import emlib
+from xmipp3.protocols import XmippProtDeepGlobalAssignment
+
+
+class TestDeepGlobalAssignment(BaseTest):
+    @classmethod
+    def runImportParticles(cls):
+        """ Import Particles.
+        """
+        args = {'importFrom': ProtImportParticles.IMPORT_FROM_SCIPION,
+                'sqliteFile': cls.particles,
+                'amplitudConstrast': 0.1,
+                'sphericalAberration': 2.0,
+                'voltage': 200,
+                'samplingRate': 0.99,
+                'haveDataBeenPhaseFlipped': True
+                }
+
+        # Id's should be set increasing from 1 if ### is not in the
+        # pattern
+        protImport = cls.newProtocol(ProtImportParticles, **args)
+        protImport.setObjLabel('import particles')
+        cls.launchProtocol(protImport)
+        return protImport
+
+    @classmethod
+    def setUpClass(cls):
+        setupTestProject(cls)
+
+        # Data
+        cls.dataset = DataSet.getDataSet('10010')
+        cls.particles = cls.dataset.getFile('particles')
+
+        cls.protImportParts = cls.runImportParticles()
+
+    def test(self):
+        subset = self.newProtocol(ProtSubSet,
+                                  inputFullSet=self.protImportParts.outputParticles,
+                                  chooseAtRandom=True,
+                                  nElements=400)
+        self.launchProtocol(subset)
+
+        deepGA = self.newProtocol(XmippProtDeepGlobalAssignment,
+                                   inputTrainSet=subset.outputParticles,
+                                   Xdim=128,
+                                   modelPretrain=False,
+                                   numAngModels=5,
+                                   numEpochs_ang=1,
+                                   batchSize=32,
+                                   learningRate=0.001,
+                                   sigma=8,
+                                   patience=5)
+        self.launchProtocol(deepGA)
+
+        fnModel0 = deepGA._getExtraPath("modelAngular0.h5")
+        fnModel2 = deepGA._getExtraPath("modelAngular2.h5")
+
+        if not exists(fnModel0):
+            self.assertTrue(False, fnModel0 + " does not exist")
+        if not exists(fnModel2):
+            self.assertTrue(False, fnModel2 + " does not exist")
+
+        deepGA2 = self.newProtocol(XmippProtDeepGlobalAssignment,
+                                      inputTrainSet=subset.outputParticles,
+                                      Xdim=128,
+                                      modelPretrain=True,
+                                      pretrainedModels=deepGA,
+                                      numAngModels=5,
+                                      numEpochs_ang=10,
+                                      batchSize=32,
+                                      learningRate=0.001,
+                                      sigma=8,
+                                      patience=5)
+        self.launchProtocol(deepGA2)
+
+        fnModel0 = deepGA2._getExtraPath("modelAngular0.h5")
+        if not exists(fnModel0):
+            self.assertTrue(False, fnModel0 + " does not exist")

--- a/xmipp3/tests/test_protocol_deep_global_assignment_predict.py
+++ b/xmipp3/tests/test_protocol_deep_global_assignment_predict.py
@@ -1,0 +1,94 @@
+# **************************************************************************
+# *
+# * Authors:    Adrian Sansinena Rodriguez  (adrian.sansinena@cnb.csic.es)
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+
+from pyworkflow.tests import BaseTest, DataSet, setupTestProject
+
+from pwem.protocols import (ProtImportParticles, ProtSubSet,
+                            exists)
+
+from pwem import emlib
+from xmipp3.protocols import XmippProtDeepGlobalAssignmentPredict, XmippProtDeepGlobalAssignment
+
+
+class TestDeepGlobalAssignmentPredict(BaseTest):
+    @classmethod
+    def runImportParticles(cls):
+        """ Import Particles.
+        """
+        args = {'importFrom': ProtImportParticles.IMPORT_FROM_SCIPION,
+                'sqliteFile': cls.particles,
+                'amplitudConstrast': 0.1,
+                'sphericalAberration': 2.0,
+                'voltage': 200,
+                'samplingRate': 0.99,
+                'haveDataBeenPhaseFlipped': True
+                }
+
+        protImport = cls.newProtocol(ProtImportParticles, **args)
+        protImport.setObjLabel('import particles')
+        cls.launchProtocol(protImport)
+        return protImport
+
+    @classmethod
+    def setUpClass(cls):
+        setupTestProject(cls)
+
+        # Data
+        cls.dataset = DataSet.getDataSet('10010')
+        cls.particles = cls.dataset.getFile('particles')
+
+        cls.protImportParts = cls.runImportParticles()
+
+    def test(self):
+        subset = self.newProtocol(ProtSubSet,
+                                  inputFullSet=self.protImportParts.outputParticles,
+                                  chooseAtRandom=True,
+                                  nElements=400)
+        self.launchProtocol(subset)
+
+        deepGA = self.newProtocol(XmippProtDeepGlobalAssignment,
+                                  inputTrainSet=subset.outputParticles,
+                                  Xdim=128,
+                                  modelPretrain=False,
+                                  numAngModels=5,
+                                  numEpochs_ang=1,
+                                  batchSize=32,
+                                  learningRate=0.001,
+                                  sigma=8,
+                                  patience=5)
+        self.launchProtocol(deepGA)
+
+        deepGAPredict = self.newProtocol(XmippProtDeepGlobalAssignmentPredict,
+                                      inputImageSet=subset.outputParticles,
+                                      Xdim=128,
+                                      inputModel=deepGA,
+                                      numAngModels=5,
+                                      tolerance=45,
+                                      maxModels=3)
+        self.launchProtocol(deepGAPredict)
+
+        self.assertIsNotNone(deepGAPredict.outputParticles,
+                             "There was a problem with Deep Center Predict")


### PR DESCRIPTION
4 new protocols that performs centering and global assignment of  a set of particles:
- deep_center: uses a labeled set of particles to train CNN-model(s) to center particles
- deep_center_predict: uses input trained model(s) to predict centers of an input set of particles
- deep_global_assignment: uses a labeled set of particles to train CNN-model(s) to perform global assignment of Euler angles
- deep_global_assignment_predict: uses input trained model(s) to assign angles of an input set of particles