### PR TITLE
Actions: Show compile log if compilation fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,8 +74,9 @@ jobs:
       env:
         BUILD_TESTS: True
       run: |
-        ../scipion/scipion3 run ./xmipp
+        ../scipion/scipion3 run ./xmipp || (cat compileLOG.txt && false)
         cat compileLOG.txt
+    #TODO: Remove last "cat compileLOG.txt" once there is a new Scipion release 
     
     # Check out the repository in the pull request
     - name: Checkout repository


### PR DESCRIPTION
It won't do anything until there is a new Scipion release. That's because in the current release version, running `scipion run <command>`, always retuns 0 (as if command completed successfully), while the command could have failed.

This is fixed in devel, but, until next release, I'll be leaving the cat compileLOG.txt command always active just in case.