### PR TITLE
Fixed movie resize output size

### DIFF
--- a/xmipp3/protocols/protocol_preprocess/protocol_movie_resize.py
+++ b/xmipp3/protocols/protocol_preprocess/protocol_movie_resize.py
@@ -170,6 +170,10 @@ class XmippProtMovieResize(ProtProcessMovies):
             imgOut.setAcquisition(movie.getAcquisition())
             imgOut.setSamplingRate(self.newSamplingRate)
             imgOut.setFramesRange(self.inputMovies.get().getFramesRange())
+            
+            if imageSet.isEmpty():
+                imageSet.setDim(imgOut.getDim())
+            
             imageSet.append(imgOut)
 
         self._updateOutputSet('outputMovies', imageSet, streamMode)

--- a/xmipp3/protocols/protocol_preprocess/protocol_movie_resize.py
+++ b/xmipp3/protocols/protocol_preprocess/protocol_movie_resize.py
@@ -195,13 +195,11 @@ class XmippProtMovieResize(ProtProcessMovies):
             outputSet.loadAllProperties()
             outputSet.enableAppend()
         else:
+            inputMovies = self.inputMovies.get()
             outputSet = SetClass(filename=setFile)
             outputSet.setStreamState(outputSet.STREAM_OPEN)
-
-        inputMovies = self.inputMovies.get()
-        outputSet.copyInfo(inputMovies)
-
-        outputSet.setSamplingRate(self.newSamplingRate)
+            outputSet.copyInfo(inputMovies)
+            outputSet.setSamplingRate(self.newSamplingRate)
 
         return outputSet
 


### PR DESCRIPTION
Movie resize was reporting an incorrect output size. We manually forced the size in the Scipion set