### PR TITLE
Tilt analysis protocol: fixes in the generated tilt images and in updating correctly the output sets

### DIFF
--- a/xmipp3/protocols/protocol_tilt_analysis.py
+++ b/xmipp3/protocols/protocol_tilt_analysis.py
@@ -32,7 +32,7 @@ import math
 from datetime import datetime
 from collections import OrderedDict
 from pyworkflow import VERSION_3_0
-from pyworkflow.protocol import STEPS_PARALLEL
+from pyworkflow.protocol import STEPS_PARALLEL, Protocol
 from pyworkflow.protocol.params import (PointerParam, IntParam,
                                         BooleanParam, LEVEL_ADVANCED, FloatParam, GE, GT, Range)
 import pyworkflow.utils as pwutils
@@ -47,7 +47,7 @@ from xmipp3.convert import getScipionObj
 from matplotlib import pyplot as plt
 
 
-class XmippProtTiltAnalysis(ProtMicrographs):
+class XmippProtTiltAnalysis(ProtMicrographs, Protocol):
     """ Estimate the tilt of a micrograph, by analyzing the PSD correlations of different segments of the image.
     """
     _label = 'tilt analysis'
@@ -345,7 +345,7 @@ class XmippProtTiltAnalysis(ProtMicrographs):
         window_image = ImageHandler().createImage()
         rotatedWind_psd = ImageHandler().createImage()
         output_image = ImageHandler().createImage()
-        output_array = np.zeros((subWindStep * 2, subWindStep * 2))
+        output_array = np.zeros(((subWindStep * 2)-1, (subWindStep * 2)-1))
         ih = ImageHandler()
 
         for i in range(0, 3, 2):
@@ -439,22 +439,6 @@ class XmippProtTiltAnalysis(ProtMicrographs):
         outputSet.copyInfo(inputMicrographs)
 
         return outputSet
-
-    def _updateOutputSet(self, outputName, outputSet, state=Set.STREAM_OPEN):
-        outputSet.setStreamState(state)
-        if self.hasAttribute(outputName):
-            outputSet.write()  # Write to commit changes
-            outputAttr = getattr(self, outputName)
-            # Copy the properties to the object contained in the protocol
-            outputAttr.copy(outputSet, copyId=False)
-            # Persist changes
-            self._store(outputAttr)
-        else:
-            # Here the defineOutputs function will call the write() method
-            self._defineOutputs(**{outputName: outputSet})
-            self._store(outputSet)
-        # Close set databaset to avoid locking it
-        outputSet.close()
 
     # ------------------------- UTILS functions --------------------------------
     def _correctFormat(self, micName, micFn, micFolderTmp):

--- a/xmipp3/viewers/viewer.py
+++ b/xmipp3/viewers/viewer.py
@@ -203,7 +203,7 @@ class XmippViewer(DataViewer):
                                               viewParams={ORDER: labels,
                                                           VISIBLE: labels,
                                                           RENDER: labelRender,
-                                                          ZOOM: 25,
+                                                          ZOOM: 5,
                                                           MODE: MODE_MD}))
 
             if obj.hasAttribute('outputMicrographs'):
@@ -216,7 +216,7 @@ class XmippViewer(DataViewer):
                                                    viewParams={ORDER: labels,
                                                    VISIBLE: labels,
                                                    RENDER: labelRender,
-                                                   ZOOM: 25,
+                                                   ZOOM: 5,
                                                    MODE: MODE_MD}))
 
             if not(obj.hasAttribute('discardedMicrographs')) and not(obj.hasAttribute('outputMicrographs')):


### PR DESCRIPTION
- Remove the extra empty space in the generated tilt images
- Update correctly the output sets using scipions generic method