### PR TITLE
JMK fix filter choices

### DIFF
--- a/xmipp3/protocols/protocol_preprocess/protocol_filter.py
+++ b/xmipp3/protocols/protocol_preprocess/protocol_filter.py
@@ -119,7 +119,7 @@ class XmippFilterHelper():
         #fourier
 
         form.addParam('freqInAngstrom', BooleanParam, default=True,
-                      condition='filterSpace == %d' % FILTER_SPACE_FOURIER,
+                      condition='filterSpace == %d and filterModeFourier != %d' % (FILTER_SPACE_FOURIER, cls.FM_CTF),
                       label='Provide resolution in Angstroms?',
                       help='If *Yes*, the resolution values for the filter\n'
                            'should be provided in Angstroms. If *No*, the\n'

--- a/xmipp3/protocols/protocol_preprocess/protocol_filter.py
+++ b/xmipp3/protocols/protocol_preprocess/protocol_filter.py
@@ -69,11 +69,11 @@ class XmippFilterHelper():
 
     #--------------------------- DEFINE param functions --------------------------------------------
     @classmethod
-    def _defineProcessParams(cls, form):
+    def _defineProcessParams(cls, form, fourier_choices=['low pass', 'high pass', 'band pass', 'ctf']):
         form.addParam('filterSpace', EnumParam, choices=['fourier', 'real', 'wavelets'],
                       default=FILTER_SPACE_FOURIER,
                       label="Filter space")
-        form.addParam('filterModeFourier', EnumParam, choices=['low pass', 'high pass', 'band pass', 'ctf'],
+        form.addParam('filterModeFourier', EnumParam, choices=fourier_choices,
                       default=cls.FM_BAND_PASS,
                       condition='filterSpace == %d' % FILTER_SPACE_FOURIER,
                       label="Filter mode",
@@ -433,7 +433,7 @@ class XmippProtFilterVolumes(ProtFilterVolumes, XmippProcessVolumes):
 
     #--------------------------- DEFINE param functions --------------------------------------------
     def _defineProcessParams(self, form):
-        XmippFilterHelper._defineProcessParams(form)
+        XmippFilterHelper._defineProcessParams(form, fourier_choices=['low pass', 'high pass', 'band pass'])
         
     def _insertProcessStep(self):
         XmippFilterHelper._insertProcessStep(self)


### PR DESCRIPTION
1. freq in Angstrom Boolean shouldn't be shown when filter mode is CTF
2. CTF isn't a valid option for volumes so the _defineProcessParams function is copied and modified for the volume protocol