### PR TITLE
Different protocols: Set the micrograph pointers as indirect pointers for streaming purpose

### DIFF
--- a/xmipp3/convert/io_coordinates.py
+++ b/xmipp3/convert/io_coordinates.py
@@ -17,9 +17,10 @@ def readSetOfCoordsFromPosFnames(posDir, setOfInputCoords, sqliteOutName,
     """
 
     inputMics = setOfInputCoords.getMicrographs()
+    inputMicsPointer = setOfInputCoords.getMicrographs(asPointer=True)
     cleanPath(sqliteOutName)
     setOfOutputCoordinates= SetOfCoordinates(filename= sqliteOutName)
-    setOfOutputCoordinates.setMicrographs(inputMics)
+    setOfOutputCoordinates.setMicrographs(inputMicsPointer)
     setOfOutputCoordinates.setBoxSize(setOfInputCoords.getBoxSize())
     readSetOfCoordinates(posDir, micSet=inputMics,
                            coordSet=setOfOutputCoordinates,

--- a/xmipp3/protocols/protocol_deep_micrograph_screen.py
+++ b/xmipp3/protocols/protocol_deep_micrograph_screen.py
@@ -426,8 +426,7 @@ class XmippProtDeepMicrographScreen(ProtExtractParticles, XmippProtocol):
         """ Return the micrographs pointer associated to the SetOfCoordinates or
         Other micrographs. """
         if not self._micsOther():
-            inMicsPointer = Pointer(self.getMapper().getParent(self.inputCoordinates.get().getMicrographs()),
-                                    extended='outputMicrographs')
+            inMicsPointer = self.getCoords().getMicrographs(asPointer=True)
             return inMicsPointer
         else:
             return self.inputMicrographs

--- a/xmipp3/protocols/protocol_screen_deepConsensus.py
+++ b/xmipp3/protocols/protocol_screen_deepConsensus.py
@@ -1189,7 +1189,8 @@ class XmippProtScreenDeepConsensus(ProtParticlePicking, XmippProtocol):
 
     def getPreCoordinatesOutput(self):
       print('Creating new preliminarOutputCoordinates set')
-      self.preliminarOutputCoordinates = self._createSetOfCoordinates(self.coordinatesDict['OR'].getMicrographs())
+      self.preliminarOutputCoordinates = \
+          self._createSetOfCoordinates(self.coordinatesDict['OR'].getMicrographs(asPointer=True))
       self.preliminarOutputCoordinates.copyInfo(self.coordinatesDict['OR'])
       self.preliminarOutputCoordinates.setBoxSize(self._getBoxSize())
       self.preliminarOutputCoordinates.setStreamState(SetOfParticles.STREAM_OPEN)
@@ -1203,7 +1204,7 @@ class XmippProtScreenDeepConsensus(ProtParticlePicking, XmippProtocol):
     def getCoordinatesOutput(self):
       if not hasattr(self, "outputCoordinates"):
         print('Creating new outputCoordinates set')
-        self.outputCoordinates = self._createSetOfCoordinates(self.coordinatesDict['OR'].getMicrographs())
+        self.outputCoordinates = self._createSetOfCoordinates(self.coordinatesDict['OR'].getMicrographs(asPointer=True))
         self.outputCoordinates.copyInfo(self.coordinatesDict['OR'])
         self.outputCoordinates.setBoxSize(self._getBoxSize())
         self.outputCoordinates.setStreamState(SetOfParticles.STREAM_OPEN)
@@ -1214,7 +1215,7 @@ class XmippProtScreenDeepConsensus(ProtParticlePicking, XmippProtocol):
         self.USING_INPUT_COORDS = False
       else:
         # Micrographs of the set removed because there might be new ones in streaming
-        self.outputCoordinates.setMicrographs(self.coordinatesDict['OR'].getMicrographs())
+        self.outputCoordinates.setMicrographs(self.coordinatesDict['OR'].getMicrographs(asPointer=True))
       return self.outputCoordinates
 
     def getPreParticlesOutput(self, partSet):


### PR DESCRIPTION
Affects the following protocols:
- Micrograph cleaner
- Deep picking consensus 
- Pick Noise