### PR TITLE
Read from CIF

### DIFF
--- a/xmipp3/protocols/protocol_validate_fscq.py
+++ b/xmipp3/protocols/protocol_validate_fscq.py
@@ -165,7 +165,10 @@ class XmippProtValFit(ProtAnalysis3D):
     def convertInputStep(self):
         """ Convert inputs to desired format."""
         #Convert Input to pdb
-        if self.getInputStructFile().endswith('.pdb') or self.getInputStructFile().endswith('.ent') or self.getInputStructFile().endswith('.cif'):
+        if (self.getInputStructFile().endswith('.pdb') or 
+            self.getInputStructFile().endswith('.ent') or 
+            self.getInputStructFile().endswith('.cif') or
+            self.getInputStructFile().endswith('.cif.gz')):
             os.symlink(os.path.abspath(self.getInputStructFile()), self.getPDBFile())
         else:
             toPdb(self.getInputStructFile(), self.getPDBFile())

--- a/xmipp3/protocols/protocol_validate_fscq.py
+++ b/xmipp3/protocols/protocol_validate_fscq.py
@@ -165,7 +165,7 @@ class XmippProtValFit(ProtAnalysis3D):
     def convertInputStep(self):
         """ Convert inputs to desired format."""
         #Convert Input to pdb
-        if self.getInputStructFile().endswith('.pdb') or self.getInputStructFile().endswith('.ent'):
+        if self.getInputStructFile().endswith('.pdb') or self.getInputStructFile().endswith('.ent') or self.getInputStructFile().endswith('.cif'):
             os.symlink(os.path.abspath(self.getInputStructFile()), self.getPDBFile())
         else:
             toPdb(self.getInputStructFile(), self.getPDBFile())


### PR DESCRIPTION
As there is an implementation in the base xmipp repository ([840](https://github.com/I2PC/xmipp/pull/840)) that allows native CIF file handling, conversion to PDB is not needed any more for those files.