### PR TITLE
Fix local resolution to local bfactor

### DIFF
--- a/xmipp3/protocols/protocol_resolution_bfactor.py
+++ b/xmipp3/protocols/protocol_resolution_bfactor.py
@@ -137,8 +137,13 @@ class XmippProtbfactorResolution(ProtAnalysis3D):
     def convertInputStep(self):
         """ Read the input volume and check the file extension to convert to mrc is it is the case.
         """
-        self.vol = self.mrc_convert(self.localResolutionMap.get().getFileName(),
-                                    self._getTmpPath('localResolutionMap.mrc'))
+        if self.normalizeResolution.get():
+            self.inputMap = self.localResolutionMap
+        else:
+            self.inputMap = self.normalizedMap
+
+        self.vol = self.mrc_convert(self.inputMap.get().getFileName(),
+                                    self._getTmpPath('localResolutionMap.mrc'))        
 
     def matchingBfactorLocalResolution(self):
         """ The local resolution map and the pdb are taken and analyzed to match the
@@ -151,7 +156,7 @@ class XmippProtbfactorResolution(ProtAnalysis3D):
         params += ' --vol %s' % self.vol
         if self.normalizeResolution.get():
             params += ' --fscResolution %s' % self.fscResolution.get()
-        params += ' --sampling %f' % self.localResolutionMap.get().getSamplingRate()
+        params += ' --sampling %f' % self.inputMap.get().getSamplingRate()
         if self.medianEstimation.get():
             params += ' --useMedian '
         if self.centered.get():

--- a/xmipp3/protocols/protocol_resolution_bfactor.py
+++ b/xmipp3/protocols/protocol_resolution_bfactor.py
@@ -70,13 +70,13 @@ class XmippProtbfactorResolution(ProtAnalysis3D):
 
         form.addParam('normalizeResolution', BooleanParam, default=True,
                       label="Normalize Resolution",
-                      help='The normalizedlocal resolution map is defined as'
-                           '(LR - FSC)/FSC, where LR is the local resolution of a'
+                      help='The normalizedlocal resolution map is defined as '
+                           '(LR - FSC)/FSC, where LR is the local resolution of a '
                            'given voxel, and FSC is the FSC resolution in A. This '
-                           'map provides information about whether the local resolution is'
+                           'map provides information about whether the local resolution is '
                            'greater or lesser than the FSC. The local resolution '
-                           'normalized map is used to carry out the matching with the local'
-                           'bfactor per residue. Yes means that the local resolution will be'
+                           'normalized map is used to carry out the matching with the local '
+                           'bfactor per residue. Yes means that the local resolution will be '
                            'normalized by the algorithm. No means that the input local '
                            'resolution map is already a normalized local resolution map.')
 
@@ -85,7 +85,7 @@ class XmippProtbfactorResolution(ProtAnalysis3D):
                       condition='normalizeResolution',
                       help='Select a local resolution map. Alternatively, the input.'
                            ' can be a normalized local resolution map, in this case'
-                           'set the Normalize resolution to No')
+                           ' set the Normalize resolution to No')
 
         form.addParam('normalizedMap', PointerParam, pointerClass='Volume',
                       label="Normalized Local Resolution Map", important=True,
@@ -93,7 +93,7 @@ class XmippProtbfactorResolution(ProtAnalysis3D):
                       help='Select a normalized local resolution map. The local'
                            ' resolution normalized map is defined as '
                            '(LR - FSC)/FSC, where LR is the local resolution of a'
-                           'given voxel, and FSC is the FSC resolution in A')
+                           ' given voxel, and FSC is the FSC resolution in A')
 
         form.addParam('fscResolution', FloatParam,
                       condition = 'normalizeResolution',
@@ -102,7 +102,7 @@ class XmippProtbfactorResolution(ProtAnalysis3D):
 
         form.addParam('medianEstimation', BooleanParam, default=True,
                       label="Use median",
-                      help='The local resolution per residue can be estimated using'
+                      help='The local resolution per residue can be estimated using '
                            'the mean (by default - No) or the median (yes)')
 
         form.addParam('centered', BooleanParam, default=True,

--- a/xmipp3/tests/test_protocols_xmipp_3d.py
+++ b/xmipp3/tests/test_protocols_xmipp_3d.py
@@ -2754,6 +2754,14 @@ class TestXmippResolutionBfactor(TestXmippBase):
                                                  fscResolution=8.35)
         self.launchProtocol(protbfactorResolution)
 
+        # Protocol local resolution/local bfactor with assuming already normalized
+        print("Protocol local resolution/local bfactor")
+        protbfactorResolution = self.newProtocol(XmippProtbfactorResolution,
+                                                 normalizeResolution=False,
+                                                 pdbfile=protImportPdb.outputPdb,
+                                                 normalizedMap=protCreateMap.resolution_Volume)
+        self.launchProtocol(protbfactorResolution)
+
 class TestXmippLocalVolAdjust(TestXmippBase):
 
     @classmethod


### PR DESCRIPTION
Before the attribute normalizedMap wasn't used and it would try and use localResolutionMap even if it wasn't set

![image](https://github.com/I2PC/scipion-em-xmipp/assets/13259162/9b451c6a-7680-4156-9ee4-560ea93bd70a)
