### PR TITLE
fix convert pdb inputs and validate

### DIFF
--- a/xmipp3/protocols/protocol_convert_pdb.py
+++ b/xmipp3/protocols/protocol_convert_pdb.py
@@ -70,7 +70,7 @@ class XmippProtConvertPdb(ProtInitialVolume):
         This definition is also used to generate automatically the GUI.
         """
         # Defining condition string for x, y, z coords
-        coordsCondition = 'setSize and not vol'
+        coordsCondition = 'setSize and not vol and not isinstance(pdbObj, SetOfAtomStructs)'
 
         # Defining parallel arguments
         form.addParallelSection(threads=4, mpi=1)
@@ -253,6 +253,9 @@ class XmippProtConvertPdb(ProtInitialVolume):
         # Checking if MPI is selected (only threads are allowed)
         if self.numberOfMpi > 1:
             errors.append('MPI cannot be selected, because Scipion is going to drop support for it. Select threads instead.')
+
+        if isinstance(self.pdbObj.get(), SetOfAtomStructs) and not self.size.hasValue():
+            errors.append('Please set size when using SetOfAtomStructs as input')
 
         return errors
     


### PR DESCRIPTION
I'm not sure why we have 1 size value when having a set as input and 3 of them when having a single pdb as input, but this makes the interface easier for coping with that. Before, the 3 size values would stay shown when changing the input after already selecting to set size, and now they get hidden. 

I've also added a validation option as when we input a set of pdbs, we have to put in a size or the protocol fails