### PR TITLE
Local average added

### DIFF
--- a/xmipp3/protocols/protocol_extract_particles.py
+++ b/xmipp3/protocols/protocol_extract_particles.py
@@ -570,6 +570,7 @@ class XmippProtExtractParticles(ProtExtractParticles, XmippProtocol):
                         # adding the variance and Gini coeff. value of the mic zone
                         setXmippAttributes(p, row, md.MDL_SCORE_BY_VAR)
                         setXmippAttributes(p, row, md.MDL_SCORE_BY_GINI)
+                        setXmippAttributes(p, row, md.MDL_LOCAL_AVERAGE)
                         if row.containsLabel(md.MDL_ZSCORE_DEEPLEARNING1):
                             setXmippAttributes(p, row, md.MDL_ZSCORE_DEEPLEARNING1)
 


### PR DESCRIPTION
Extract particles now annotates the average intensity value around the particle in the original particle.