### PR TITLE
add missing space in ctf help

### DIFF
--- a/xmipp3/protocols/protocol_ctf_micrographs.py
+++ b/xmipp3/protocols/protocol_ctf_micrographs.py
@@ -132,7 +132,7 @@ class XmippProtCTFMicrographs(ProtCTFMicrographs):
                            'and if it fails, -1.')
         form.addParam('refineAmplitudeContrast', params.BooleanParam, default=False,
                       label='Allow amplitude constrast refinement',
-                      help = 'The amplitude contrast is normally kept fixed, but in'
+                      help = 'The amplitude contrast is normally kept fixed, but in '
                              'some experiments it has been found that refining it '
                              'might result in some improvement in the final FSC. '
                              'This is not a standard practice, and should be used with caution')


### PR DESCRIPTION
One of the ones on the end of a line that's easy to miss until you open up scipion