### PR TITLE
Updated scikit-learn version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 scipion-pyworkflow>=3.0.31
-scikit-learn==0.22
+scikit-learn==1.1
 scipion-em
 scipy<=1.10.0
 joblib


### PR DESCRIPTION
Updated version to allow python > 3.4.
scikit-learn 1.1 requires python >=3.6
deepConsensus works with scikit-learn 1.1