### PR TITLE
Locally adjust Particle's CTF according to the micrograph's tilt angle

### DIFF
--- a/xmipp3/protocols/__init__.py
+++ b/xmipp3/protocols/__init__.py
@@ -35,6 +35,7 @@ from .protocol_angular_resolution_alignment import XmippProtResolutionAlignment
 from .protocol_preprocess.protocol_add_noise import (XmippProtAddNoiseVolumes,
                                                      XmippProtAddNoiseParticles)
 from .protocol_apply_alignment import XmippProtApplyAlignment
+from .protocol_apply_tilt_to_ctf import XmippProtApplyTiltToCtf
 from .protocol_apply_transformation_matrix import XmippProtApplyTransformationMatrix
 from .protocol_break_symmetry import XmippProtAngBreakSymmetry
 from .protocol_cl2d_align import XmippProtCL2DAlign

--- a/xmipp3/protocols/protocol_apply_tilt_to_ctf.py
+++ b/xmipp3/protocols/protocol_apply_tilt_to_ctf.py
@@ -29,11 +29,11 @@ from pyworkflow.utils.properties import Message
 
 from pwem.objects import (Particle, Coordinate, Micrograph, CTFModel,
                           SetOfParticles)
-from pwem.protocols import ProtCTFAssign
+from pwem.protocols import EMProtocol
 
 import math
 
-class XmippProtApplyTiltToCtf(ProtCTFAssign):
+class XmippProtApplyTiltToCtf(EMProtocol):
     """ Apply a local deviation to the CTF based on the micrograph's tilt
     angle"""
     _label = 'apply tilt to ctf'

--- a/xmipp3/protocols/protocol_apply_tilt_to_ctf.py
+++ b/xmipp3/protocols/protocol_apply_tilt_to_ctf.py
@@ -88,8 +88,9 @@ class XmippProtApplyTiltToCtf(EMProtocol):
         # Compute the CTF offset
         coordinate: Coordinate = particle.getCoordinate()
         micrograph: Micrograph = coordinate.getMicrograph()
+        dimensions = micrograph.getXDim(), micrograph.getYDim()
         position = coordinate.getPosition()
-        r = position[self.tiltIndex]
+        r = position[self.tiltIndex] - (dimensions[self.tiltIndex] / 2)
         r *= micrograph.getSamplingRate() # Convert to angstroms.
         dy = self.sineFactor*r
         

--- a/xmipp3/protocols/protocol_apply_tilt_to_ctf.py
+++ b/xmipp3/protocols/protocol_apply_tilt_to_ctf.py
@@ -1,0 +1,85 @@
+# **************************************************************************
+# *
+# * Authors:     Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+
+import pyworkflow.protocol.params as params
+from pyworkflow.utils.properties import Message
+
+from pwem.objects import (Particle, Coordinate, Micrograph, CTFModel,
+                          SetOfParticles)
+from pwem.protocols import ProtCTFAssign
+        
+class XmippProtApplyTiltToCtf(ProtCTFAssign):
+    """ Apply a local deviation to the CTF based on the micrograph's tilt
+    angle"""
+    _label = 'apply tilt to ctf'
+    _tilt_axes = ['X', 'Y']
+
+    #--------------------------- DEFINE param functions --------------------------------------------
+    def _defineParams(self, form):
+        form.addSection(label='Input')
+        form.addParam('inputParticles', params.PointerParam, label=Message.LABEL_INPUT_PART,
+                      pointerClass=SetOfParticles, pointerCondition='hasCTF',
+                      important=True,
+                      help='Select the particles that you want to apply the'
+                           'local CTF correction.')
+        form.addParam('tiltAxis', params.EnumParam, label='Tilt axis', 
+                      choices=self._tilt_axes, default=1,
+                      help='The tilt axis. In tomography this is Y by convention.')
+        form.addParam('tiltAngle', params.FloatParam, label='Tilt angle',
+                      default=0, validators=[params.Range(-90, 90)],
+                      help='The angle at which the acquisition is tilted. '
+                      'In degrees. Mind the sign of the angle.')
+        
+    #--------------------------- INSERT steps functions --------------------------------------------
+    
+    def _insertAllSteps(self):
+        self._insertFunctionStep('createOutputStep')        
+
+    #--------------------------- STEPS functions --------------------------------------------        
+    def createOutputStep(self):
+        inputParticles: SetOfParticles = self.inputParticles.get()
+        outputParticles: SetOfParticles = self._createSetOfParticles()
+        
+        outputParticles.copyItems(inputParticles,
+                                  updateItemCallback=self._updateItem )
+     
+        self._defineOutputs(outputParticles=outputParticles)
+        self._defineSourceRelation(self.inputParticles, outputParticles)
+    
+    #--------------------------- UTILS functions --------------------------------------------
+    def _updateItem(self, particle: Particle, _):
+        coordinate: Coordinate = particle.getCoordinate()
+        if coordinate is not None:
+            # Compute the CTF offset
+            micrograph: Micrograph = coordinate.getMicrograph()
+            position = coordinate.getPosition()
+            r = position[self.tiltAxis.get()]
+            delta = r*micrograph.getSamplingRate() # Convert to angstroms.
+            
+            # Write to output
+            ctf: CTFModel = particle.getCTF()
+            ctf.setDefocusU(ctf.getDefocusU() + delta)
+            ctf.setDefocusV(ctf.getDefocusV() + delta)

--- a/xmipp3/protocols/protocol_apply_tilt_to_ctf.py
+++ b/xmipp3/protocols/protocol_apply_tilt_to_ctf.py
@@ -38,6 +38,7 @@ class XmippProtApplyTiltToCtf(EMProtocol):
     angle"""
     _label = 'apply tilt to ctf'
     _tilt_axes = ['X', 'Y']
+    _tilt_signs = ['Increasing', 'Decreasing']
 
     #--------------------------- DEFINE param functions --------------------------------------------
     def _defineParams(self, form):
@@ -51,9 +52,13 @@ class XmippProtApplyTiltToCtf(EMProtocol):
                       choices=self._tilt_axes, default=1,
                       help='The tilt axis. In tomography this is Y by convention.')
         form.addParam('tiltAngle', params.FloatParam, label='Tilt angle',
-                      default=0, validators=[params.Range(-90, 90)],
+                      default=0, validators=[params.Range(0, 90)],
                       help='The angle at which the acquisition is tilted. '
-                      'In degrees. Mind the sign of the angle.')
+                      'In degrees.')
+        form.addParam('tiltSign', params.EnumParam, label='Tilt sign',
+                      choices=self._tilt_signs, default=0,
+                      help='Wether defocus increases or decreases in terms '
+                      'of the selected tilt axis.')
         
     #--------------------------- INSERT steps functions --------------------------------------------
     
@@ -66,8 +71,10 @@ class XmippProtApplyTiltToCtf(EMProtocol):
         outputParticles: SetOfParticles = self._createSetOfParticles()
         
         TILT_INDICES = [1, 0]
-        self.sineFactor = math.sin(math.radians(self.tiltAngle.get()))
+        SIGNS = [+1, -1]
+        sign = SIGNS[self.tiltSign.get()]
         self.tiltIndex = TILT_INDICES[self.tiltAxis.get()]
+        self.sineFactor = sign*math.sin(math.radians(self.tiltAngle.get()))
         
         outputParticles.copyInfo(inputParticles)
         outputParticles.copyItems(inputParticles,

--- a/xmipp3/protocols/protocol_apply_tilt_to_ctf.py
+++ b/xmipp3/protocols/protocol_apply_tilt_to_ctf.py
@@ -65,7 +65,10 @@ class XmippProtApplyTiltToCtf(EMProtocol):
         inputParticles: SetOfParticles = self.inputParticles.get()
         outputParticles: SetOfParticles = self._createSetOfParticles()
         
+        TILT_INDICES = [1, 0]
         self.sineFactor = math.sin(math.radians(self.tiltAngle.get()))
+        self.tiltIndex = TILT_INDICES[self.tiltAxis.get()]
+        
         outputParticles.copyInfo(inputParticles)
         outputParticles.copyItems(inputParticles,
                                   updateItemCallback=self._updateItem )
@@ -79,7 +82,7 @@ class XmippProtApplyTiltToCtf(EMProtocol):
         coordinate: Coordinate = particle.getCoordinate()
         micrograph: Micrograph = coordinate.getMicrograph()
         position = coordinate.getPosition()
-        r = position[self.tiltAxis.get()]
+        r = position[self.tiltIndex]
         r *= micrograph.getSamplingRate() # Convert to angstroms.
         dy = self.sineFactor*r
         

--- a/xmipp3/viewers/__init__.py
+++ b/xmipp3/viewers/__init__.py
@@ -28,6 +28,7 @@ from .viewer import XmippViewer
 from .plotter import XmippPlotter
 
 from .viewer_angular_resolution_alignment import XmippProtAngResAlignViewer
+from .viewer_apply_tilt_to_ctf import XmippApplyTiltToCTFViewer
 from .viewer_cl2d import XmippCL2DViewer
 from .viewer_ctf_consensus import XmippCTFConsensusViewer
 from .viewer_deep_consensus import XmippDeepConsensusViewer

--- a/xmipp3/viewers/viewer_apply_tilt_to_ctf.py
+++ b/xmipp3/viewers/viewer_apply_tilt_to_ctf.py
@@ -1,0 +1,81 @@
+# **************************************************************************
+# *
+# * Authors:     Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+
+from pyworkflow.viewer import (ProtocolViewer, DESKTOP_TKINTER, WEB_DJANGO)
+import pyworkflow.protocol.params as params
+
+from pwem.objects import SetOfParticles, CTFModel, Coordinate
+
+from xmipp3.protocols.protocol_apply_tilt_to_ctf import XmippProtApplyTiltToCtf
+
+import matplotlib.pyplot as plt
+
+class XmippApplyTiltToCTFViewer(ProtocolViewer):
+    """ Visualization of the output of apply_tilt_to_ctf protocol
+    """
+    _label = 'viewer apply tilt to ctg'
+    _targets = [XmippProtApplyTiltToCtf]
+    _environments = [DESKTOP_TKINTER, WEB_DJANGO]
+
+    def __init__(self, **kwargs):
+        ProtocolViewer.__init__(self, **kwargs)
+
+    def _defineParams(self, form):
+        form.addSection(label='Visualization')
+        form.addParam('displayLocalDefocus', params.IntParam, label='Display local defocus of micrograph:',
+                      help="""Type the ID of the micrograph to see particle local defocus of the selected micrograph. 
+                      It is possible that not all the micrographs are available.
+                      Please check the ID of the micrographs in the output set of micrographs of this protocol.""")
+
+    def _getVisualizeDict(self):
+        return {
+            'displayLocalDefocus': self._viewLocalDefocus,
+        }
+
+    def _viewLocalDefocus(self, _):
+        particles: SetOfParticles = self.protocol.outputParticles
+        micrographId: int = self.displayLocalDefocus.get()
+        
+        x = []
+        y = []
+        defocus = []
+        for particle in particles.iterItems(where='_micId=%d' % micrographId):
+            coordinate: Coordinate = particle.getCoordinate()
+            ctf: CTFModel = particle.getCTF()
+            
+            x.append(coordinate.getX())
+            y.append(coordinate.getY())
+            defocus.append((ctf.getDefocusU() + ctf.getDefocusV()) / 2)
+                
+        
+        fig = plt.figure()
+        ax = fig.add_subplot(projection='3d')
+        ax.scatter(x, y, defocus)
+        ax.set_xlabel('X coordinate')
+        ax.set_ylabel('Y coordinate')
+        ax.set_zlabel('Defocus')
+        
+        return [fig]


### PR DESCRIPTION
Correct local CTF to account for a tilt angle in the acquisition. Useful for a niche acquisition method where the sample is tilted to avoid preferential orientations.