### PR TITLE
Add multi-GPU support to Xmipp3 FlexAlign

### DIFF
--- a/xmipp3/protocols/protocol_flexalign.py
+++ b/xmipp3/protocols/protocol_flexalign.py
@@ -77,11 +77,6 @@ class XmippProtFlexAlign(ProtAlignMovies):
         form._paramsDict['Alignment']._paramList.remove('Crop_offsets__px_')
         form._paramsDict['Alignment']._paramList.remove('Crop_dimensions__px_')
 
-        form.addHidden(params.USE_GPU, params.BooleanParam, default=True,
-                       label="Use GPU for execution",
-                       help="This protocol has both CPU and GPU implementation.\
-                       Select the one you want to use.")
-
         form.addHidden(params.GPU_LIST, params.StringParam, default='0',
                        expertLevel=cons.LEVEL_ADVANCED,
                        label="Choose GPU IDs",
@@ -162,7 +157,7 @@ class XmippProtFlexAlign(ProtAlignMovies):
                       help="Flip gain reference after rotation. "
                            "For tiff movies, gain is automatically upside-down flipped")
 
-        form.addParallelSection(threads=1, mpi=1)
+        form.addParallelSection(threads=1, mpi=2)
 
         
 

--- a/xmipp3/protocols/protocol_flexalign.py
+++ b/xmipp3/protocols/protocol_flexalign.py
@@ -70,6 +70,7 @@ class XmippProtFlexAlign(ProtAlignMovies):
                        expertLevel=cons.LEVEL_ADVANCED,
                        label="Choose GPU IDs",
                        help="Add a list of GPU devices that can be used")
+        form.addHidden(params.USE_GPU, params.BooleanParam, default=True, label="Use GPU or CPU implementation of the algorithm.")
 
         ProtAlignMovies._defineAlignmentParams(self, form)
 


### PR DESCRIPTION
I detected that FlexAlign could easily do multi-GPU processing with a few line changes, thanks to the new streaming and scheduling capabilities in Scipion and to Strelak's preventive programming.

This PR adds the ability of running FlexAlign multiple times in a single GPU or in multiple GPUs from within Scipion3.

Bsos,
Mikel