### PR TITLE
fix simulate ctf pre-CTF noise np.numpy

### DIFF
--- a/xmipp3/protocols/protocol_simulate_ctf.py
+++ b/xmipp3/protocols/protocol_simulate_ctf.py
@@ -121,7 +121,7 @@ class XmippProtSimulateCTF(Prot2D):
             if self.noiseBefore>0:
                 I=xmippLib.Image(fnIn)
                 Idata = I.getData()
-                I.setData(Idata+self.noiseBefore.get()*np.numpy.random.Generator.normal(size=Idata.shape))
+                I.setData(Idata+self.noiseBefore.get()*np.random.Generator.normal(size=Idata.shape))
                 I.write(fnOut)
                 fnIn=fnOut
 


### PR DESCRIPTION
This is in the block for adding pre-CTF noise so maybe wasn't tested much