### PR TITLE
Fix FSCQ test

### DIFF
--- a/xmipp3/tests/test_protocol_validate_fscq.py
+++ b/xmipp3/tests/test_protocol_validate_fscq.py
@@ -41,8 +41,8 @@ class TestValidateFSCQ(BaseTest):
   def _runImportPDB(cls):
     protImportPDB = cls.newProtocol(
       ProtImportPdb,
-      inputPdbData=1,
-      pdbFile=cls.ds.getFile('PDBx_mmCIF/5ni1.pdb'))
+      inputPdbData=0,
+      pdbId="5ni1")
     cls.launchProtocol(protImportPDB)
     cls.protImportPDB = protImportPDB
 


### PR DESCRIPTION
FSCQ test was not passing due to a wrong conversion done by Chimera (import pdb from file -> PDB -> CIF). 

Instead of relying on a local file, we can import directly from the database to avoid the conversion.