### PR TITLE
deepLearningToolkit working with Apptainer

### DIFF
--- a/xmipp3/__init__.py
+++ b/xmipp3/__init__.py
@@ -216,6 +216,22 @@ class Plugin(pwem.Plugin):
                     os.path.isfile(os.path.join(bundleDir, 'xmipp')))
         
         return bundleDir if isBundle else None
+
+def getNvidiaDriverVersion(plugin):
+    """ Several ways to retrieve NVIDIA driver version.
+    """
+    commands = [["nvidia-smi", "--query-gpu=driver_version", "--format=csv,noheader"],
+                ["cat", "/sys/module/nvidia/version"]]
+    for cmd in commands:
+        try:
+            nvidiaDriverVer = subprocess.Popen(cmd,
+                                               env=plugin.getEnviron(),
+                                               stdout=subprocess.PIPE
+                                               ).stdout.read().decode('utf-8').split(".")[0]
+            return nvidiaDriverVer
+        except (ValueError, TypeError, FileNotFoundError):
+            continue
+    return None
     
 def installDeepLearningToolkit(plugin, env):
 
@@ -223,38 +239,32 @@ def installDeepLearningToolkit(plugin, env):
     cudaMsgs = []
     nvidiaDriverVer = None
     if os.environ.get('CUDA', 'True') == 'True':
-        try:
-            nvidiaDriverVer = subprocess.Popen(["nvidia-smi",
-                                                "--query-gpu=driver_version",
-                                                "--format=csv,noheader"],
-                                               env=plugin.getEnviron(),
-                                               stdout=subprocess.PIPE
-                                               ).stdout.read().decode('utf-8').split(".")[0]
-            if int(nvidiaDriverVer) < NVIDIA_DRIVERS_MINIMUM_VERSION:
-                preMsgs.append("Incompatible driver %s" % nvidiaDriverVer)
-                cudaMsgs.append(f"Your NVIDIA drivers are too old (<{NVIDIA_DRIVERS_MINIMUM_VERSION}). "
-                                "Tensorflow was installed without GPU support. "
-                                "Just CPU computations enabled (slow computations)."
-                                f"To enable CUDA (drivers>{NVIDIA_DRIVERS_MINIMUM_VERSION} needed), "
-                                "set CUDA=True in 'scipion.conf' file")
-                nvidiaDriverVer = None
-        except (ValueError, TypeError, FileNotFoundError):
-            nvidiaDriverVer = None
-            preMsgs.append("Not nvidia driver found. Type: "
-                           " nvidia-smi --query-gpu=driver_version --format=csv,noheader")
-            preMsgs.append(
-                "CUDA will NOT be USED. (not found or incompatible)")
-            msg = ("Tensorflow installed without GPU. Just CPU computations "
-                   "enabled (slow computations).")
-            cudaMsgs.append(msg)
-            useGpu = False
+        nvidiaDriverVer = getNvidiaDriverVersion(plugin)
 
-    if nvidiaDriverVer is not None:
-        preMsgs.append("CUDA support found. Driver version: %s" % nvidiaDriverVer)
-        msg = "Tensorflow will be installed with CUDA SUPPORT."
+    if nvidiaDriverVer is None:
+        preMsgs.append("Not nvidia driver found. Type: "
+                       " nvidia-smi --query-gpu=driver_version --format=csv,noheader")
+        preMsgs.append(
+            "CUDA will NOT be USED. (not found or incompatible)")
+        msg = ("Tensorflow installed without GPU. Just CPU computations "
+               "enabled (slow computations).")
         cudaMsgs.append(msg)
-        useGpu = True
+        useGpu = False
 
+    else:
+        if int(nvidiaDriverVer) < NVIDIA_DRIVERS_MINIMUM_VERSION:
+            preMsgs.append("Incompatible driver %s" % nvidiaDriverVer)
+            cudaMsgs.append(f"Your NVIDIA drivers are too old (<{NVIDIA_DRIVERS_MINIMUM_VERSION}). "
+                            "Tensorflow was installed without GPU support. "
+                            "Just CPU computations enabled (slow computations)."
+                            f"To enable CUDA (drivers>{NVIDIA_DRIVERS_MINIMUM_VERSION} needed), "
+                            "set CUDA=True in 'scipion.conf' file")
+            useGpu = False
+        else:
+            preMsgs.append("CUDA support found. Driver version: %s" % nvidiaDriverVer)
+            msg = "Tensorflow will be installed with CUDA SUPPORT."
+            cudaMsgs.append(msg)
+            useGpu = True
 
     # commands  = [(command, target), (cmd, tgt), ...]
     cmdsInstall = list(CondaEnvManager.yieldInstallAllCmds(useGpu=useGpu))

--- a/xmipp3/__init__.py
+++ b/xmipp3/__init__.py
@@ -231,7 +231,6 @@ def getNvidiaDriverVersion(plugin):
             return nvidiaDriverVer
         except (ValueError, TypeError, FileNotFoundError):
             continue
-    return None
     
 def installDeepLearningToolkit(plugin, env):
 

--- a/xmipp3/protocols/protocol_resolution_deepres.py
+++ b/xmipp3/protocols/protocol_resolution_deepres.py
@@ -37,13 +37,13 @@ from pyworkflow.utils import getExt
 from pwem.objects import Volume
 import xmipp3
 
-# def updateEnviron(gpuNum):
-#     """ Create the needed environment for TensorFlow programs. """
-#     print("updating environ to select gpu %s" % (gpuNum))
-#     if gpuNum == '':
-#         os.environ['CUDA_VISIBLE_DEVICES'] = '0'
-#     else:
-#         os.environ['CUDA_VISIBLE_DEVICES'] = str(gpuNum)
+def updateEnviron(gpuNum):
+    """ Create the needed environment for TensorFlow programs. """
+    print("updating environ to select gpu %s" % (gpuNum))
+    if gpuNum == '':
+        os.environ['CUDA_VISIBLE_DEVICES'] = '0'
+    else:
+        os.environ['CUDA_VISIBLE_DEVICES'] = str(gpuNum)
 
 DEEPRES_METHOD_URL = 'https://github.com/I2PC/scipion/wiki/XmippProtDeepRes'
 RESIZE_MASK = 'binaryMask.vol' 
@@ -125,8 +125,8 @@ class XmippProtDeepRes(ProtAnalysis3D, xmipp3.XmippProtocol):
     def _insertAllSteps(self):
             # Convert input into xmipp Metadata format
 
-        # if not self.useQueueForSteps() and not self.useQueue():
-        #     updateEnviron(self.gpuList.get())
+        if not self.useQueueForSteps() and not self.useQueue():
+            updateEnviron(self.gpuList.get())
             
         self._createFilenameTemplates() 
         self._insertFunctionStep('convertInputStep')

--- a/xmipp3/protocols/protocol_resolution_deepres.py
+++ b/xmipp3/protocols/protocol_resolution_deepres.py
@@ -37,13 +37,13 @@ from pyworkflow.utils import getExt
 from pwem.objects import Volume
 import xmipp3
 
-def updateEnviron(gpuNum):
-    """ Create the needed environment for TensorFlow programs. """
-    print("updating environ to select gpu %s" % (gpuNum))
-    if gpuNum == '':
-        os.environ['CUDA_VISIBLE_DEVICES'] = '0'
-    else:
-        os.environ['CUDA_VISIBLE_DEVICES'] = str(gpuNum)
+# def updateEnviron(gpuNum):
+#     """ Create the needed environment for TensorFlow programs. """
+#     print("updating environ to select gpu %s" % (gpuNum))
+#     if gpuNum == '':
+#         os.environ['CUDA_VISIBLE_DEVICES'] = '0'
+#     else:
+#         os.environ['CUDA_VISIBLE_DEVICES'] = str(gpuNum)
 
 DEEPRES_METHOD_URL = 'https://github.com/I2PC/scipion/wiki/XmippProtDeepRes'
 RESIZE_MASK = 'binaryMask.vol' 
@@ -125,8 +125,8 @@ class XmippProtDeepRes(ProtAnalysis3D, xmipp3.XmippProtocol):
     def _insertAllSteps(self):
             # Convert input into xmipp Metadata format
 
-        if not self.useQueueForSteps() and not self.useQueue():
-            updateEnviron(self.gpuList.get())
+        # if not self.useQueueForSteps() and not self.useQueue():
+        #     updateEnviron(self.gpuList.get())
             
         self._createFilenameTemplates() 
         self._insertFunctionStep('convertInputStep')


### PR DESCRIPTION
The installation of deepLearningToolkit creates several conda environments such as "xmipp_DLTK_v0.3", which include the tensorflow python module. The way it checks if tensorflow should be installed in CPU or GPU mode is by executing "nvidia-smi". The issue is that when installing it through Appatainer, at the time of building the container, you don't have access to the GPU host resources, so you can't execute "nvidia-smi". Instead, GPU access becomes available later, when you actually run the previously built container. Therefore, this is an alternative way to check if the host machine has a GPU.