### PR TITLE
better label for volume 1 vs 2

### DIFF
--- a/xmipp3/protocols/protocol_volume_adjust_sub.py
+++ b/xmipp3/protocols/protocol_volume_adjust_sub.py
@@ -46,7 +46,7 @@ class XmippProtVolAdjBase(EMProtocol):
     @classmethod
     def _defineParams(self, form):
         form.addSection(label='Input')
-        form.addParam('vol1', PointerParam, pointerClass='Volume', label="Volume 1 ", help='Specify a volume.')
+        form.addParam('vol1', PointerParam, pointerClass='Volume', label="Volume 1 (reference)", help='Specify a volume.')
         form.addParam('masks', BooleanParam, label='Mask volumes?', default=True,
                       help='The masks are not mandatory but highly recommendable.')
         form.addParam('mask1', PointerParam, pointerClass='VolumeMask', label="Mask for volume 1",
@@ -125,7 +125,7 @@ class XmippProtVolSubtraction(XmippProtVolAdjBase):
         form.addParam('pdbFile', FileParam,
                       label="File path", condition='inputPdbData == IMPORT_FROM_FILES and pdb', allowsNull=True,
                       help='Specify a path to desired PDB structure.')
-        form.addParam('vol2', PointerParam, pointerClass='Volume', label="Volume 2 ", condition='pdb == False',
+        form.addParam('vol2', PointerParam, pointerClass='Volume', label="Volume 2", condition='pdb == False',
                       help='Specify a volume.')
         form.addParam('mask2', PointerParam, pointerClass='VolumeMask', label="Mask for volume 2",
                       condition='masks and pdb==False', help='Specify a mask for volume 1.')
@@ -271,7 +271,7 @@ class XmippProtVolAdjust(XmippProtVolAdjBase):
     # --------------------------- DEFINE param functions --------------------------------------------
     def _defineParams(self, form):
         XmippProtVolAdjBase._defineParams(form)
-        form.addParam('vol2', PointerParam, pointerClass='Volume', label="Volume 2 ", help='Specify a volume.')
+        form.addParam('vol2', PointerParam, pointerClass='Volume', label="Volume 2 (to modify)", help='Specify a volume.')
         form.addParam('mask2', PointerParam, pointerClass='VolumeMask', label="Mask for volume 2",
                       condition='masks', help='Specify a mask for volume 1.')
 

--- a/xmipp3/protocols/protocol_volume_adjust_sub.py
+++ b/xmipp3/protocols/protocol_volume_adjust_sub.py
@@ -264,7 +264,7 @@ class XmippProtVolAdjust(XmippProtVolAdjBase):
     The volume with the best resolution should be the first one.
     The volumes should be aligned previously and they have to be equal in size"""
 
-    _label = 'volumes adjust'
+    _label = 'volume adjust'
     IMPORT_OBJ = 0
     IMPORT_FROM_FILES = 1
 


### PR DESCRIPTION
It's not useful for users to just see Volume 1 and Volume 2. I had no idea a priori which one was the one that would be modified. I have confirmed against the xmipp program, and this matches what Carlos Oscar said:
```
	addParamsLine("--i1 <volume>			: Reference volume");
	addParamsLine("--i2 <volume>			: Volume to modify");
	addParamsLine("[-o <structure=\"\">]\t: Volume 2 modified or "
			"volume difference");
```