### PR TITLE
The Exploration of the WriteSetOfParticles and the Missing ExtraLabels

### DIFF
--- a/xmipp3/convert/convert.py
+++ b/xmipp3/convert/convert.py
@@ -477,7 +477,7 @@ def imageToRow(img, imgRow, imgLabel, **kwargs):
         acquisitionToRow(img.getAcquisition(), imgRow)
 
     # Write all extra labels to the row
-    objectToRow(img, imgRow, {}, extraLabels=IMAGE_EXTRA_LABELS)
+    objectToRow(img, imgRow, {}, extraLabels=IMAGE_EXTRA_LABELS + kwargs.get('extraLabels', []))
 
     # Provide a hook to be used if something is needed to be
     # done for special cases before converting image to row


### PR DESCRIPTION
**The Oier and Fede Adventures: The Exploration of the WriteSetOfParticles and the Missing ExtraLabels**

In another whimsical adventure, Oier and Fede embark on a quest to hunt down the most elusive bugs in Xmipp. This episode features the WriteSetOfParticles and the mysterious missing ExtraLabels. Despite being ancient code, it turns out no one had ever ventured into these lands before. Fortunately, our humble heroes were able to solve the problem once again.

For centuries, songs of these deeds will be sung.