### PR TITLE
protocol_particle_pick_consensus: Changes inn functionality and some errors

### DIFF
--- a/xmipp3/protocols/protocol_movie_alignment_consensus.py
+++ b/xmipp3/protocols/protocol_movie_alignment_consensus.py
@@ -78,7 +78,7 @@ class XmippProtConsensusMovieAlignment(ProtAlignMovies, Protocol):
                       label="Secondary Aligned Movies",
                       help='Shift to be compared with reference alignment')
 
-        form.addParam('minConsCorrelation', params.FloatParam, default=-1,
+        form.addParam('minConsCorrelation', params.FloatParam, default=0.75,
                       label='Minimum consensus shifts correlation',
                       help="Minimum value for the consensus correlations between shifts trajectories."
                            "\nIf there are noticeable discrepancies between the two estimations below this correlation,"
@@ -227,47 +227,31 @@ class XmippProtConsensusMovieAlignment(ProtAlignMovies, Protocol):
         S1[0, :] = shiftX_1
         S1[1, :] = shiftY_1
         S2[0, :] = shiftX_2
-        S2[2, :] = shiftY_2
+        S2[1, :] = shiftY_2
 
         # Translation through subtraction of the center of mass
-        S1c1 = np.mean(S1[0, :], axis=1, keepdims=True)
-        S1c2 = np.mean(S1[1, :], axis=1, keepdims=True)
-        S2c1 = np.mean(S2[0, :], axis=1, keepdims=True)
-        S2c2 = np.mean(S2[2, :], axis=1, keepdims=True)
+        S1c = np.mean(S1, axis=1, keepdims=True)
+        S2c = np.mean(S2, axis=1, keepdims=True)
 
-        S11 = S1[0, :] - S1c1
-        S12 = S1[1, :] - S1c2
-        S21 = S2[0, :] - S2c1
-        S22 = S2[2, :] - S2c2
+        S11 = S1 - S1c
+        S22 = S2 - S2c
 
-        S1n = np.array([S11, S12, np.ones(len(shiftX_1))])
-        S2n = np.array([S21, np.ones(len(shiftX_2)), S22])
-
-        print("S1= ", S1)
-        print("S2= ", S2)
-        print("S11= ", S11)
-        print("S22= ", S22)
-        print("S11= ", S1n)
-        print("S22= ", S2n)
+        S11[2, :] = np.ones(len(shiftX_1))
+        S22[2, :] = np.ones(len(shiftY_1))
 
         # SVD Decomposition
-        H = np.dot(S2n, S1n.T)
+        H = np.dot(S22, S11.T)
         U, _, VT = np.linalg.svd(H)
         R = np.dot(VT.T, U.T)
         if np.linalg.det(R)<0:
             VT[-1, :] = -VT[-1, :]
             R = np.dot(VT.T, U.T)
-        S1 = np.dot(R, S2) + S1c - np.dot(R, S2c)
 
-        print("H= ", np.linalg.det(H))
-
-        A = np.dot(np.dot(S1, S2.T), np.linalg.inv(np.dot(S2, S2.T)))
-        S2_p = np.dot(A, S2)
+        S2_p = np.dot(R, S22) + S1c
+        S2_p[2, :] = np.ones(len(shiftY_1))
 
         S1_cart = np.array([S1[0, :]/S1[2, :], S1[1, :]/S1[2, :]])
-        print("S1cart= ", S1_cart)
         S2_p_cart = np.array([S2_p[0, :] / S2_p[2, :], S2_p[1, :] / S2_p[2, :]])
-        print("S2pcart= ", S2_p_cart)
         rmse_cart = np.sqrt((np.square(S1_cart - S2_p_cart)).mean())
         maxe_cart = np.max(S1_cart - S2_p_cart)
         corrX_cart = np.corrcoef(S1_cart[0, :], S2_p_cart[0, :])[0, 1]

--- a/xmipp3/protocols/protocol_particle_pick_consensus.py
+++ b/xmipp3/protocols/protocol_particle_pick_consensus.py
@@ -149,7 +149,7 @@ class XmippProtConsensusPicking(ProtParticlePicking):
         self._checkNewOutput()
 
     def _checkNewInput(self):
-        # If continue from an stopped run, don't repeat what is done
+        # If continue from a stopped run, don't repeat what is already done
         if not self.checkedMics:
             for fn in getFiles(self._getExtraPath()):
                 fn = removeBaseExt(fn)
@@ -169,9 +169,14 @@ class XmippProtConsensusPicking(ProtParticlePicking):
                 readyMics.intersection_update(currentPickMics)
             allMics = allMics.union(currentPickMics)
 
+        mainPickMics = getReadyMics(self.inputCoordinates[0].get())[0]
+        secondaryPickMics = getReadyMics(self.inputCoordinates[1].get())[0]
+        if not mainPickMics == secondaryPickMics:
+            allMics = mainPickMics.intersection(secondaryPickMics)
+
         self.streamClosed = all(streamClosed)
         if self.streamClosed:
-            # for non streaming do all and in the last iteration of streaming do the rest
+            # for non-streaming do all and in the last iteration of streaming do the rest
             newMicIds = allMics.difference(self.checkedMics)
         else:  # for streaming processing, only go for the ready mics in all pickers
             if readyMics is not None:
@@ -179,10 +184,8 @@ class XmippProtConsensusPicking(ProtParticlePicking):
 
         if newMicIds:
             self.checkedMics.update(newMicIds)
-
             inMics = self.getMainInput().getMicrographs()
             newMics = [inMics[micId].clone() for micId in newMicIds]
-
             fDeps = self.insertNewCoorsSteps(newMics)
             outputStep = self._getFirstJoinStep()
             if outputStep is not None:
@@ -223,8 +226,8 @@ class XmippProtConsensusPicking(ProtParticlePicking):
                 outputStep.setStatus(STATUS_NEW)
 
     def defineRelations(self, outputSet):
-        for inCorrds in self.inputCoordinates:
-            self._defineTransformRelation(inCorrds, outputSet)
+        for inCoords in self.inputCoordinates:
+            self._defineTransformRelation(inCoords, outputSet)
 
     def _loadOutputSet(self, SetClass, baseName):
         setFile = self._getPath(baseName)


### PR DESCRIPTION
When selecting and picking particles from two different sets of coordinates, there were some errors regarding the correct use of IDs from each set when their length and IDs were different from each other. That led to discrepancies such as "'NoneType' object has no attribute 'X' ", being X an specific attribute, due to some variables appearing when indexing by ID as 'None'. Now, that is corrected, and the protocol now can be used also for assymetrical sets.