### PR TITLE
protocol_particle_pick_consensus: Changes in functionality and errors

### DIFF
--- a/xmipp3/protocols/protocol_particle_pick_consensus.py
+++ b/xmipp3/protocols/protocol_particle_pick_consensus.py
@@ -169,6 +169,11 @@ class XmippProtConsensusPicking(ProtParticlePicking):
                 readyMics.intersection_update(currentPickMics)
             allMics = allMics.union(currentPickMics)
 
+        mainPickMicks = getReadyMics(self.inputCoordinates[0].get())[0]
+        secondaryPickMicks = getReadyMics(self.inputCoordinates[1].get())[0]
+        if not mainPickMicks == secondaryPickMicks:
+            allMics = mainPickMicks.intersection(secondaryPickMicks)
+
         self.streamClosed = all(streamClosed)
         if self.streamClosed:
             # for non streaming do all and in the last iteration of streaming do the rest


### PR DESCRIPTION
Some changes were made in this protocol due to some malfunctions regarding the selection and indexing of some variables by IDs. The lengths of each set of coordinates provided by a certain number of micrograph were different and their IDs were too, adding to problems such as "'NoneType' object has no attribute 'X'", being X an specific attribute, when indexing by wrong IDs.