### PR TITLE
protocol_particle_pick_consensus: Changes in functionality

### DIFF
--- a/xmipp3/protocols/protocol_particle_pick_consensus.py
+++ b/xmipp3/protocols/protocol_particle_pick_consensus.py
@@ -169,6 +169,11 @@ class XmippProtConsensusPicking(ProtParticlePicking):
                 readyMics.intersection_update(currentPickMics)
             allMics = allMics.union(currentPickMics)
 
+        mainPickMics = getReadyMics(self.inputCoordinates[0].get())[0]
+        secondaryPickMics = getReadyMics(self.inputCoordinates[1].get())[0]
+        if not mainPickMics == secondaryPickMics:
+            allMics = mainPickMics.intersection(secondaryPickMics)
+
         self.streamClosed = all(streamClosed)
         if self.streamClosed:
             # for non streaming do all and in the last iteration of streaming do the rest

--- a/xmipp3/protocols/protocol_particle_pick_consensus.py
+++ b/xmipp3/protocols/protocol_particle_pick_consensus.py
@@ -171,7 +171,7 @@ class XmippProtConsensusPicking(ProtParticlePicking):
 
         mainPickMics = getReadyMics(self.inputCoordinates[0].get())[0]
         secondaryPickMics = getReadyMics(self.inputCoordinates[1].get())[0]
-        if not mainPickMics == secondaryPickMics:
+        if mainPickMics != secondaryPickMics:
             allMics = mainPickMics.intersection(secondaryPickMics)
 
         self.streamClosed = all(streamClosed)


### PR DESCRIPTION
When selecting and picking particles from two different sets of coordinates, there were some errors regarding the correct use of IDs from each set when their length and IDs were different from each other. That led to discrepancies such as "'NoneType' object has no attribute 'X' ", being X an specific attribute, due to some variables appearing when indexing by ID as 'None'. Now, that is corrected, and the protocol now can be used also for assymetrical sets.