### PR TITLE
[Hotfix Release] Disabling installation of dependency package by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,10 @@ jobs:
       with:
         ref: ${{ github.head_ref }}
 
-    - name: Install dependencies 
+    - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libopenmpi-dev openmpi-bin python3-numpy git 
+        sudo apt-get install -y libfftw3-dev libopenmpi-dev libhdf5-dev libtiff5-dev libsqlite3-dev default-jdk git cmake openmpi-bin gcc g++
 
     - name: Install CUDA
       uses: Jimver/cuda-toolkit@master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Release 3.25.06.1 - Rhea
+- Disabling the default installation of dependencies to prevent breaking the scipion environment
+
 ## Release 3.25.06.0 - Rhea
 - New protocols
    - compute_likelihood: This protocol computes the likelihood of a set of particles with assigned angles when compared to a set of maps or atomic modelS

--- a/xmipp3/__init__.py
+++ b/xmipp3/__init__.py
@@ -174,7 +174,7 @@ class Plugin(pwem.Plugin):
                 tar='void.tgz',
                 commands=commands.getCommands(),
                 neededProgs=['conda'],
-                default=True
+                default=False
             )
         
         if develMode:

--- a/xmipp3/version.py
+++ b/xmipp3/version.py
@@ -29,7 +29,7 @@ type_of_version = 'release' #'release' 'devel'
 _logo = "xmipp_logo" + ("" if type_of_version == 'release' else '_devel') + '.png'
 
 _binVersion = 'v3.25.06.0' # Increase it if hotfix in binaries (xmipp, xmippCore and/or XmippViz)
-_pluginVersion = 'v3.25.06.0' # Increase it if hotfix in binaries (xmipp, xmippCore and/or XmippViz) or in scipion-em-xmipp
+_pluginVersion = 'v3.25.06.1' # Increase it if hotfix in binaries (xmipp, xmippCore and/or XmippViz) or in scipion-em-xmipp
 
 _binTagVersion = _binVersion + '-Rhea' #'devel' or _binVersion + '-Poseidon'
 _pluginTagVersion = _pluginVersion + '-Rhea'  #'devel' or _pluginVersion + '-Poseidon'


### PR DESCRIPTION
Xmipp dependency package is breaking many Scipion installations, requiring to install Xmipp from scratch