### PR TITLE
Revert fragile plugin reload Hotfix?

### DIFF
--- a/xmipp3/__init__.py
+++ b/xmipp3/__init__.py
@@ -58,22 +58,22 @@ class Plugin(pwem.Plugin):
     _supportedVersions = []
     _url = XMIPP_URL
     _condaRootPath = None
-    # # Refressing the plugin
-    # # Inspects the call stack to find 'installPipModule' and sets 'self._plugin' to None.
-    # # Uses CPython's internal API 'PyFrame_LocalsToFast' to sync changes.
-    # # Risky and CPython-specific; use only if redesign is not possible.
-    # try:
-    #     import inspect
-    #     import ctypes
-    #     for frameInfo in inspect.stack():
-    #         if frameInfo.function == "installPipModule":
-    #             frame = frameInfo[0]
-    #             frame.f_locals['self']._plugin = None
-    #             ctypes.pythonapi.PyFrame_LocalsToFast(
-	# 			    ctypes.py_object(frame),
-	# 			    ctypes.c_int(1))
-    # except Exception as e:
-    #     print(e)
+    # Refressing the plugin
+    # Inspects the call stack to find 'installPipModule' and sets 'self._plugin' to None.
+    # Uses CPython's internal API 'PyFrame_LocalsToFast' to sync changes.
+    # Risky and CPython-specific; use only if redesign is not possible.
+    try:
+        import inspect
+        import ctypes
+        for frameInfo in inspect.stack():
+            if frameInfo.function == "installPipModule":
+                frame = frameInfo[0]
+                frame.f_locals['self']._plugin = None
+                ctypes.pythonapi.PyFrame_LocalsToFast(
+				    ctypes.py_object(frame),
+				    ctypes.c_int(1))
+    except Exception as e:
+        print(e)
     
     @classmethod
     def _defineVariables(cls):

--- a/xmipp3/version.py
+++ b/xmipp3/version.py
@@ -40,6 +40,6 @@ _binVersion = 'v6' # Increase it if major release is generated in xmipp
 # - If several of the above are true, only change the biggest one applicable (
 #   for example, if a fix is made and a new protocol are included in the same
 #   pull request, increase the one related to the new protocol).
-__version__ = '29.0.0'
+__version__ = '29.0.1'
 
 _currentDepVersion = '1.1'


### PR DESCRIPTION
This PR fixes an issue where updating the Xmipp plugin through the Scipion Plugin Manager installs the latest plugin version but continues using the previously loaded version.py module instead of reloading it. As a result, the old _binVersion value (v5) is kept in memory instead of the updated one (v6), causing the Plugin Manager to install the previous Xmipp binaries rather than the correct version. 

The fixrevert the PR: https://github.com/I2PC/scipion-em-xmipp/pull/1016/changes